### PR TITLE
Fixed PRUDP v0 packet signature checks always failing

### DIFF
--- a/nintendo/nex/prudp.py
+++ b/nintendo/nex/prudp.py
@@ -264,7 +264,7 @@ class PRUDPMessageV0:
 			
 			#Verify packet signature
 			expected_signature = self.calc_packet_signature(packet, self.client.source_signature)
-			if signature != expected_signature:
+			if packet.signature != expected_signature:
 				logger.error(
 					"(V0) Invalid packet signature (expected %s, got %s)",
 					signature.hex(), expected_signature.hex()


### PR DESCRIPTION
I noticed that little mistake when I was reimplementing a friend server and testing it through this client, so there's a patch