### PR TITLE
Bugfixes

### DIFF
--- a/nintendo/files/config/default.cfg
+++ b/nintendo/files/config/default.cfg
@@ -8,6 +8,7 @@ prudp.resend_limit = 3
 prudp.ping_timeout = 4
 prudp.silence_timeout = 7.5
 prudp.compression = 0
+prudp.support = -1
 
 prudp_v0.signature_version = 0
 prudp_v0.flags_version = 1

--- a/nintendo/nex/prudp.py
+++ b/nintendo/nex/prudp.py
@@ -26,10 +26,6 @@ FLAG_NEED_ACK = 4
 FLAG_HAS_SIZE = 8
 FLAG_MULTI_ACK = 0x200
 
-#I ran into issues when I was missing a support
-#flag, so I'm just setting all bits to 1 here
-SUPPORT_ALL = 0xFFFFFFFF
-
 OPTION_SUPPORT = 0
 OPTION_CONNECTION_SIG = 1
 OPTION_FRAGMENT = 2
@@ -322,7 +318,7 @@ class PRUDPMessageV1:
 	def encode_options(self, packet):
 		options = b""
 		if packet.type in [TYPE_SYN, TYPE_CONNECT]:
-			options += struct.pack("<BBI", OPTION_SUPPORT, 4, SUPPORT_ALL)
+			options += struct.pack("<BBI", OPTION_SUPPORT, 4, self.client.support)
 			options += struct.pack("<BB16s", OPTION_CONNECTION_SIG, 16, packet.signature)
 			if packet.type == TYPE_CONNECT:
 				options += struct.pack("<BBH", OPTION_3, 2, random.randint(0, 0xFFFF))
@@ -431,7 +427,7 @@ class PRUDPLiteMessage:
 	def encode_options(self, packet):
 		options = b""
 		if packet.type in [TYPE_SYN, TYPE_CONNECT]:
-			options += struct.pack("<BBI", OPTION_SUPPORT, 4, SUPPORT_ALL)
+			options += struct.pack("<BBI", OPTION_SUPPORT, 4, self.client.support)
 		if packet.type == TYPE_CONNECT:
 			options += struct.pack("<BB16s", OPTION_CONNECTION_SIG_LITE, 16, packet.signature)
 		return options
@@ -546,6 +542,12 @@ class PRUDPClient:
 		self.ping_timeout = settings.get("prudp.ping_timeout")
 		self.silence_timeout = settings.get("prudp.silence_timeout")
 		self.use_compression = settings.get("prudp.compression")
+		self.support = settings.get("prudp.support")
+
+		# I ran into issues when I was missing a support
+		# flag, so I'm just setting all bits to 1 here
+		if self.support == -1:
+			self.support = 0xFFFFFFFF
 		
 		self.sock = sock
 		if not self.sock:

--- a/nintendo/settings.py
+++ b/nintendo/settings.py
@@ -18,6 +18,7 @@ class Settings:
 		"prudp.ping_timeout": float,
 		"prudp.silence_timeout": float,
 		"prudp.compression": int,
+		"prudp.support": int,
 		
 		"prudp_v0.signature_version": int,
 		"prudp_v0.flags_version": int,


### PR DESCRIPTION
This fixes some bugs related to the server side. SMM for example requires the `prudp.support` to be set to `4` or it will not get past the `SYN` stage.

Additionally there was a bug where the server already set the session key when doing the CONNECT ACK, but the client obviously didn't, which means it would fail the signature check and not work.

With these fixes SMM correctly connects to my dummy server:

```
smm secure server 192.168.1.3:59921
smm auth server 192.168.1.3:59900
Press enter to exit...
INFO:nintendo.nex.authentication:AuthenticationServer.login_ex()
User trying to log in: 1337
INFO:nintendo.nex.secure:SecureConnectionServer.register()
INFO:nintendo.nex.prudp:(0) Endpoint disconnected
WARNING:nintendo.nex.datastoresmm:DataStoreSmmSever.get_meta is unsupported
ERROR:nintendo.nex.prudp:Connection died
```