### PR TITLE
Proto method ids

### DIFF
--- a/generate_protocols.py
+++ b/generate_protocols.py
@@ -987,8 +987,8 @@ def generate(filename):
 		name = os.path.splitext(os.path.basename(filename))[0]
 		code = parse(name, data)
 		if code:
-			with open("nintendo/nex/%s.py" %name, "w") as f:
-				f.write(code)
+			with open("nintendo/nex/%s.py" %name, "wb") as f:
+				f.write(code.encode("utf8"))
 
 if len(sys.argv) < 2:
 	print("Usage: python generate_protocols.py <protocol...>")


### PR DESCRIPTION
A minor syntax change, to allow explicitly specifying the method id for each method.

This change is fully backwards compatible (generates the same py files for the existing proto files) and the proposed syntax is:

```
protocol DataStoreSmm : 115 {
	method method79(u32 unk1) {
		bool result;
	} = 79;
	method method81 = 81;
}
```

> It works similar to a c++ enum, for the following sequence:

```
method foo = 45;
method bar;
method baz;
method test = 70;
method blub;
```

> You will get the following method id assignments:

```
foo = 45
bar = 46
baz = 47
test = 70
blub = 71
```

> There is detection for duplicate method ids built in.

The parsing for the `= number` is a little duplicated, but I don't think it's worth the trouble extracting those 5 lines to a separate method since the logic is a little tricky.

I added the sublime-syntax file just because I use sublime text, I can remove it from the PR if you don't care for it.