### PR TITLE
Fix ResultRange to be loadable

### DIFF
--- a/nintendo/nex/common.py
+++ b/nintendo/nex/common.py
@@ -250,9 +250,13 @@ class DateTime:
 		
 		
 class ResultRange(Structure):
-	def __init__(self, offset, size):
+	def __init__(self, offset=0, size=0):
 		self.offset = offset
 		self.size = size
+
+	def load(self, stream):
+		self.offset = stream.u32()
+		self.size = stream.u32()
 	
 	def save(self, stream):
 		stream.u32(self.offset)


### PR DESCRIPTION
Previously, it required extra positional arguments in its constructor.
Made those optional, and added a load() method.