### PR TITLE
Support for Python 3.8

### DIFF
--- a/nintendo/nex/kerberos.py
+++ b/nintendo/nex/kerberos.py
@@ -44,7 +44,7 @@ class KerberosEncryption:
 	def check_hmac(self, buffer):
 		data = buffer[:-0x10]
 		checksum = buffer[-0x10:]
-		mac = hmac.new(self.key, data)
+		mac = hmac.new(self.key, data, digestmod=hashlib.md5)
 		return checksum == mac.digest()
 		
 	def decrypt(self, buffer):
@@ -54,7 +54,7 @@ class KerberosEncryption:
 		
 	def encrypt(self, buffer):
 		encrypted = self.rc4.crypt(buffer)
-		mac = hmac.new(self.key, encrypted)
+		mac = hmac.new(self.key, encrypted, digestmod=hashlib.md5)
 		return encrypted + mac.digest()
 
 

--- a/nintendo/nex/prudp.py
+++ b/nintendo/nex/prudp.py
@@ -168,7 +168,7 @@ class PRUDPMessageV0:
 			data = session_key + struct.pack("<HB", packet.packet_id, packet.fragment_id) + data
 
 		if data:
-			return hmac.new(self.client.signature_key, data).digest()[:4]
+			return hmac.new(self.client.signature_key, data, digestmod=hashlib.md5).digest()[:4]
 		return struct.pack("<I", 0x12345678)
 		
 	def calc_packet_signature(self, packet, signature):
@@ -311,7 +311,7 @@ class PRUDPMessageV1:
 	def signature_size(self): return 16
 
 	def calc_packet_signature(self, session_key, header, options, signature, payload):
-		mac = hmac.new(self.client.signature_key)
+		mac = hmac.new(self.client.signature_key, digestmod=hashlib.md5)
 		mac.update(header[4:])
 		mac.update(session_key)
 		mac.update(struct.pack("<I", self.client.signature_base))
@@ -960,7 +960,7 @@ class PRUDPClient:
 		if self.transport_type == self.settings.TRANSPORT_UDP:
 			self.local_signature = secrets.token_bytes(self.stream.signature_size())
 		else:
-			self.local_signature = hmac.new(self.signature_key, self.signature_key + self.remote_signature).digest()
+			self.local_signature = hmac.new(self.signature_key, self.signature_key + self.remote_signature, digestmod=hashlib.md5).digest()
 			
 		connect_packet = PRUDPPacket(TYPE_CONNECT, FLAG_RELIABLE | FLAG_NEED_ACK)
 		connect_packet.connection_signature = self.local_signature

--- a/nintendo/pia/lan.py
+++ b/nintendo/pia/lan.py
@@ -277,8 +277,8 @@ class LanBrowser:
 		return tag + ciphertext
 		
 	def generate_challenge_reply(self, nonce, key, challenge):
-		key = hmac.new(self.key, key, hashlib.sha256).digest()[:16]
-		data = hmac.new(self.key, challenge, hashlib.sha256).digest()[:16]
+		key = hmac.new(self.key, key, digestmod=hashlib.sha256).digest()[:16]
+		data = hmac.new(self.key, challenge, digestmod=hashlib.sha256).digest()[:16]
 		
 		aes = AES.new(key, AES.MODE_GCM, nonce=nonce)
 		ciphertext, tag = aes.encrypt_and_digest(data)

--- a/nintendo/pia/packet.py
+++ b/nintendo/pia/packet.py
@@ -1,3 +1,4 @@
+import hashlib
 
 from nintendo.common.streams import StreamIn, StreamOut
 import hmac
@@ -89,7 +90,7 @@ class PIAPacket:
 			self.messages.append(message)
 		
 		signature = stream.read(0x10)
-		if hmac.new(session_key, data[:-0x10]).digest() != signature:
+		if hmac.new(session_key, data[:-0x10], digestmod=hashlib.md5).digest() != signature:
 			logger.error("Incorrect packet signature")
 			return False
 		return True
@@ -107,5 +108,5 @@ class PIAPacket:
 			message.encode(stream)
 		
 		#Checksum
-		stream.write(hmac.new(session_key, stream.get()).digest())
+		stream.write(hmac.new(session_key, stream.get(), digestmod=hashlib.md5).digest())
 		return stream.get()


### PR DESCRIPTION
https://docs.python.org/3/library/hmac.html

> Deprecated since version 3.4, will be removed in version 3.8: MD5 as implicit default digest for digestmod is deprecated. The digestmod parameter is now required. Pass it as a keyword argument to avoid awkwardness when you do not have an initial msg.