### PR TITLE
Make certain HTTP errors more introspectable

### DIFF
--- a/nintendo/aauth.py
+++ b/nintendo/aauth.py
@@ -4,8 +4,8 @@ from Crypto.Cipher import AES, PKCS1_OAEP
 from Crypto.PublicKey import RSA
 from Crypto.Hash import SHA256
 from Crypto.Random import get_random_bytes
-from nintendo.common.http import HTTPRequest, HTTPClient, HTTPError
-from nintendo.switch import b64encode, b64decode
+from nintendo.common.http import HTTPRequest, HTTPClient
+from nintendo.switch import HTTPError, b64encode, b64decode
 import struct
 
 import logging

--- a/nintendo/baas.py
+++ b/nintendo/baas.py
@@ -56,7 +56,7 @@ class BAASClient:
 		response = self.client.request(req, True)
 		if response.status not in [200, 201]:
 			logger.warning("BAAS request returned error: %s" %response.json)
-			raise BAASError("BAAS request failed: %s" %response.json["title"])
+			raise BAASError(response.json["title"])
 		return response
 		
 	def authenticate(self, device_token):

--- a/nintendo/common/http.py
+++ b/nintendo/common/http.py
@@ -58,6 +58,16 @@ def format_date():
 	return now.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
 
+class HTTPError(Exception):
+	def __init__(self, *, status_code=None, errors=None):
+		self.status_code = status_code
+		self.errors = errors
+		if errors is not None:
+			super().__init__(errors[0]["message"])
+		else:
+			super().__init__("HTTP request failed with status code: %d" %status_code)
+
+
 class HTTPHeaders(types.CaseInsensitiveDict):
 	pass
 

--- a/nintendo/common/http.py
+++ b/nintendo/common/http.py
@@ -58,16 +58,6 @@ def format_date():
 	return now.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
 
-class HTTPError(Exception):
-	def __init__(self, *, status_code=None, errors=None):
-		self.status_code = status_code
-		self.errors = errors
-		if errors is not None:
-			super().__init__(errors[0]["message"])
-		else:
-			super().__init__("HTTP request failed with status code: %d" %status_code)
-
-
 class HTTPHeaders(types.CaseInsensitiveDict):
 	pass
 

--- a/nintendo/dauth.py
+++ b/nintendo/dauth.py
@@ -1,6 +1,6 @@
 
 from nintendo.common.http import HTTPClient, HTTPRequest, HTTPError
-from nintendo.switch import b64encode, b64decode
+from nintendo.switch import HTTPError, b64encode, b64decode
 from Crypto.Hash import CMAC
 from Crypto.Cipher import AES
 

--- a/nintendo/nnas.py
+++ b/nintendo/nnas.py
@@ -97,7 +97,11 @@ Profile.parse = lambda obj: Profile(
 )
 		
 
-class NNASError(Exception): pass
+class NNASError(Exception):
+	def __init__(self, *, status_code, text):
+		self.status_code = status_code
+		self.text = text
+		super().__init__("Account request failed with status %i" %status_code)
 
 
 class NNASClient:
@@ -202,7 +206,7 @@ class NNASClient:
 		response = self.client.request(req, True)
 		if response.error():
 			logger.error("Account request returned status code %i\n%s", response.status, response.text)
-			raise NNASError("Account request failed with status %i" %response.status)
+			raise NNASError(status_code=response.status, text=response.text)
 		return response.xml
 		
 	def login(self, username, password, password_type=None):

--- a/nintendo/nnas.py
+++ b/nintendo/nnas.py
@@ -101,7 +101,9 @@ class NNASError(Exception):
 	def __init__(self, *, status_code, text):
 		self.status_code = status_code
 		self.text = text
-		super().__init__("Account request failed with status %i" %status_code)
+
+	def __str__(self):
+		return "Account request failed with status %i" %self.status_code
 
 
 class NNASClient:

--- a/nintendo/switch.py
+++ b/nintendo/switch.py
@@ -18,7 +18,7 @@ class HTTPError(Exception):
 	def __str__(self):
 		if self.errors is not None:
 			return errors[0]["message"]
-		return "HTTP request failed with status code: %d" %self.status_code
+		return "HTTP request failed with status code: %i" %self.status_code
 
 
 def b64encode(data):

--- a/nintendo/switch.py
+++ b/nintendo/switch.py
@@ -10,6 +10,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class HTTPError(Exception):
+	def __init__(self, *, status_code=None, errors=None):
+		self.status_code = status_code
+		self.errors = errors
+
+	def __str__(self):
+		if self.errors is not None:
+			return errors[0]["message"]
+		return "HTTP request failed with status code: %d" %self.status_code
+
+
 def b64encode(data):
 	return base64.b64encode(data, b"-_").decode().rstrip("=")
 	


### PR DESCRIPTION
I want to be able to detect when my console has been banned,
but with the current code I'd have to inspect the string value of the exception, which may change on Nintendo's
end, whereas I reckon that the numeric error code won't.