### PR TITLE
Update `fpd_version` for `nasc`

### DIFF
--- a/nintendo/nasc.py
+++ b/nintendo/nasc.py
@@ -45,6 +45,7 @@ def parse_date(text):
 #	001: success
 #   109: missing or malformed parameter in request
 #   110: game server is no longer available
+#   119: fpd version is outdated
 #   121: device certificate is invalid
 #   122: uid hmac is invalid
 #   125: game id is invalid
@@ -121,7 +122,7 @@ class NASCClient:
 		self.pid_hmac = None
 		self.password = None
 		
-		self.fpd_version = 15
+		self.fpd_version = 16
 		self.environment = "L1"
 	
 	def set_context(self, context):


### PR DESCRIPTION
The current 3DS firmware version is 11.16.0. The `fpd_version` parameter needs to be updated to reflect this, otherwise login requests via nasc will return error code `119` (an outdated fpdver is passed).
Please correct me if I am wrong.