### PR TITLE
Add nintendo.switch package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
 	url = "https://github.com/kinnay/NintendoClients",
 	license = "MIT",
 	packages = [
-		"nintendo", "nintendo.nex"
+		"nintendo", "nintendo.nex", "nintendo.switch"
 	],
 	package_data = {
 		"nintendo": ["files/config/*", "files/cert/*"]


### PR DESCRIPTION
When running ``python setup.py install``, it omitted the files that moved from namespace nintendo to nintendo.switch.