### PR TITLE
datastore: Add DataStore_Miitopia_3DS protocol

### DIFF
--- a/docs/reference/nex/datastore_miitopia_3ds.md
+++ b/docs/reference/nex/datastore_miitopia_3ds.md
@@ -1,0 +1,1129 @@
+
+# Module: <code>nintendo.nex.datastore_miitopia_3ds</code>
+
+Provides a client and server for the `DataStore_MiitopiaProtocol3DS`. This page was generated automatically from `datastore_miitopia_3ds.proto`.
+
+<code>**class** [DataStore_MiitopiaClient3DS](#datastore_miitopiaclient3ds)</code><br>
+<span class="docs">The client for the `DataStore_MiitopiaProtocol3DS`.</span>
+
+<code>**class** [DataStore_MiitopiaServer3DS](#datastore_miitopiaserver3ds)</code><br>
+<span class="docs">The server for the `DataStore_MiitopiaProtocol3DS`.</span>
+
+<code>**class** [Category](#category)</code><br>
+<code>**class** [Gender](#gender)</code><br>
+
+<code>**class** [DataStoreChangeMetaCompareParam](#datastorechangemetacompareparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreChangeMetaParam](#datastorechangemetaparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreChangeMetaParamV1](#datastorechangemetaparamv1)([Structure](common.md))</code><br>
+<code>**class** [DataStoreCompletePostParam](#datastorecompletepostparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreCompletePostParamV1](#datastorecompletepostparamv1)([Structure](common.md))</code><br>
+<code>**class** [DataStoreCompleteUpdateParam](#datastorecompleteupdateparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreDeleteParam](#datastoredeleteparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreGetMetaParam](#datastoregetmetaparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreGetNewArrivedNotificationsParam](#datastoregetnewarrivednotificationsparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreGetNotificationUrlParam](#datastoregetnotificationurlparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreGetSpecificMetaParam](#datastoregetspecificmetaparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreGetSpecificMetaParamV1](#datastoregetspecificmetaparamv1)([Structure](common.md))</code><br>
+<code>**class** [DataStoreKeyValue](#datastorekeyvalue)([Structure](common.md))</code><br>
+<code>**class** [DataStoreMetaInfo](#datastoremetainfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreNotification](#datastorenotification)([Structure](common.md))</code><br>
+<code>**class** [DataStoreNotificationV1](#datastorenotificationv1)([Structure](common.md))</code><br>
+<code>**class** [DataStorePasswordInfo](#datastorepasswordinfo)([Structure](common.md))</code><br>
+<code>**class** [DataStorePermission](#datastorepermission)([Structure](common.md))</code><br>
+<code>**class** [DataStorePersistenceInfo](#datastorepersistenceinfo)([Structure](common.md))</code><br>
+<code>**class** [DataStorePersistenceInitParam](#datastorepersistenceinitparam)([Structure](common.md))</code><br>
+<code>**class** [DataStorePersistenceTarget](#datastorepersistencetarget)([Structure](common.md))</code><br>
+<code>**class** [DataStorePrepareGetParam](#datastorepreparegetparam)([Structure](common.md))</code><br>
+<code>**class** [DataStorePrepareGetParamV1](#datastorepreparegetparamv1)([Structure](common.md))</code><br>
+<code>**class** [DataStorePreparePostParam](#datastorepreparepostparam)([Structure](common.md))</code><br>
+<code>**class** [DataStorePreparePostParamV1](#datastorepreparepostparamv1)([Structure](common.md))</code><br>
+<code>**class** [DataStorePrepareUpdateParam](#datastoreprepareupdateparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRateObjectParam](#datastorerateobjectparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRatingInfo](#datastoreratinginfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRatingInfoWithSlot](#datastoreratinginfowithslot)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRatingInitParam](#datastoreratinginitparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRatingInitParamWithSlot](#datastoreratinginitparamwithslot)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRatingLog](#datastoreratinglog)([Structure](common.md))</code><br>
+<code>**class** [DataStoreRatingTarget](#datastoreratingtarget)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqGetAdditionalMeta](#datastorereqgetadditionalmeta)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqGetInfo](#datastorereqgetinfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqGetInfoV1](#datastorereqgetinfov1)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqGetNotificationUrlInfo](#datastorereqgetnotificationurlinfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqPostInfo](#datastorereqpostinfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqPostInfoV1](#datastorereqpostinfov1)([Structure](common.md))</code><br>
+<code>**class** [DataStoreReqUpdateInfo](#datastorerequpdateinfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreSearchParam](#datastoresearchparam)([Structure](common.md))</code><br>
+<code>**class** [DataStoreSearchResult](#datastoresearchresult)([Structure](common.md))</code><br>
+<code>**class** [DataStoreSpecificMetaInfo](#datastorespecificmetainfo)([Structure](common.md))</code><br>
+<code>**class** [DataStoreSpecificMetaInfoV1](#datastorespecificmetainfov1)([Structure](common.md))</code><br>
+<code>**class** [DataStoreTouchObjectParam](#datastoretouchobjectparam)([Structure](common.md))</code><br>
+<code>**class** [MiiTubeMiiInfo](#miitubemiiinfo)([Structure](common.md))</code><br>
+<code>**class** [MiiTubeSearchParam](#miitubesearchparam)([Structure](common.md))</code><br>
+<code>**class** [MiiTubeSearchResult](#miitubesearchresult)([Structure](common.md))</code><br>
+
+## DataStore_MiitopiaClient3DS
+<code>**def _\_init__**(client: [RMCClient](rmc.md#rmcclient) / [HppClient](hpp.md#hppclient))</code><br>
+<span class="docs">Creates a new [`DataStore_MiitopiaClient3DS`](#datastore_miitopiaclient3ds).</span>
+
+<code>**async def prepare_get_object_v1**(param: [DataStorePrepareGetParamV1](#datastorepreparegetparamv1)) -> [DataStoreReqGetInfoV1](#datastorereqgetinfov1)</code><br>
+<span class="docs">Calls method `1` on the server.</span>
+
+<code>**async def prepare_post_object_v1**(param: [DataStorePreparePostParamV1](#datastorepreparepostparamv1)) -> [DataStoreReqPostInfoV1](#datastorereqpostinfov1)</code><br>
+<span class="docs">Calls method `2` on the server.</span>
+
+<code>**async def complete_post_object_v1**(param: [DataStoreCompletePostParamV1](#datastorecompletepostparamv1)) -> None</code><br>
+<span class="docs">Calls method `3` on the server.</span>
+
+<code>**async def delete_object**(param: [DataStoreDeleteParam](#datastoredeleteparam)) -> None</code><br>
+<span class="docs">Calls method `4` on the server.</span>
+
+<code>**async def delete_objects**(param: list[[DataStoreDeleteParam](#datastoredeleteparam)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Calls method `5` on the server.</span>
+
+<code>**async def change_meta_v1**(param: [DataStoreChangeMetaParamV1](#datastorechangemetaparamv1)) -> None</code><br>
+<span class="docs">Calls method `6` on the server.</span>
+
+<code>**async def change_metas_v1**(data_ids: list[int], param: list[[DataStoreChangeMetaParamV1](#datastorechangemetaparamv1)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Calls method `7` on the server.</span>
+
+<code>**async def get_meta**(param: [DataStoreGetMetaParam](#datastoregetmetaparam)) -> [DataStoreMetaInfo](#datastoremetainfo)</code><br>
+<span class="docs">Calls method `8` on the server.</span>
+
+<code>**async def get_metas**(data_ids: list[int], param: [DataStoreGetMetaParam](#datastoregetmetaparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `9` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>info: list[[DataStoreMetaInfo](#datastoremetainfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def prepare_update_object**(param: [DataStorePrepareUpdateParam](#datastoreprepareupdateparam)) -> [DataStoreReqUpdateInfo](#datastorerequpdateinfo)</code><br>
+<span class="docs">Calls method `10` on the server.</span>
+
+<code>**async def complete_update_object**(param: [DataStoreCompleteUpdateParam](#datastorecompleteupdateparam)) -> None</code><br>
+<span class="docs">Calls method `11` on the server.</span>
+
+<code>**async def search_object**(param: [DataStoreSearchParam](#datastoresearchparam)) -> [DataStoreSearchResult](#datastoresearchresult)</code><br>
+<span class="docs">Calls method `12` on the server.</span>
+
+<code>**async def get_notification_url**(param: [DataStoreGetNotificationUrlParam](#datastoregetnotificationurlparam)) -> [DataStoreReqGetNotificationUrlInfo](#datastorereqgetnotificationurlinfo)</code><br>
+<span class="docs">Calls method `13` on the server.</span>
+
+<code>**async def get_new_arrived_notifications_v1**(param: [DataStoreGetNewArrivedNotificationsParam](#datastoregetnewarrivednotificationsparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `14` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>result: list[[DataStoreNotificationV1](#datastorenotificationv1)]</code><br>
+<code>has_next: bool</code><br>
+</span>
+</span>
+
+<code>**async def rate_object**(target: [DataStoreRatingTarget](#datastoreratingtarget), param: [DataStoreRateObjectParam](#datastorerateobjectparam), fetch_ratings: bool) -> [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<span class="docs">Calls method `15` on the server.</span>
+
+<code>**async def get_rating**(target: [DataStoreRatingTarget](#datastoreratingtarget), access_password: int) -> [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<span class="docs">Calls method `16` on the server.</span>
+
+<code>**async def get_ratings**(data_ids: list[int], access_password: int) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `17` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>ratings: list[list[[DataStoreRatingInfoWithSlot](#datastoreratinginfowithslot)]]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def reset_rating**(target: [DataStoreRatingTarget](#datastoreratingtarget), update_password: int) -> None</code><br>
+<span class="docs">Calls method `18` on the server.</span>
+
+<code>**async def reset_ratings**(data_ids: list[int], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Calls method `19` on the server.</span>
+
+<code>**async def get_specific_meta_v1**(param: [DataStoreGetSpecificMetaParamV1](#datastoregetspecificmetaparamv1)) -> list[[DataStoreSpecificMetaInfoV1](#datastorespecificmetainfov1)]</code><br>
+<span class="docs">Calls method `20` on the server.</span>
+
+<code>**async def post_meta_binary**(param: [DataStorePreparePostParam](#datastorepreparepostparam)) -> int</code><br>
+<span class="docs">Calls method `21` on the server.</span>
+
+<code>**async def touch_object**(param: [DataStoreTouchObjectParam](#datastoretouchobjectparam)) -> None</code><br>
+<span class="docs">Calls method `22` on the server.</span>
+
+<code>**async def get_rating_with_log**(target: [DataStoreRatingTarget](#datastoreratingtarget), access_password: int) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `23` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>rating: [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<code>log: [DataStoreRatingLog](#datastoreratinglog)</code><br>
+</span>
+</span>
+
+<code>**async def prepare_post_object**(param: [DataStorePreparePostParam](#datastorepreparepostparam)) -> [DataStoreReqPostInfo](#datastorereqpostinfo)</code><br>
+<span class="docs">Calls method `24` on the server.</span>
+
+<code>**async def prepare_get_object**(param: [DataStorePrepareGetParam](#datastorepreparegetparam)) -> [DataStoreReqGetInfo](#datastorereqgetinfo)</code><br>
+<span class="docs">Calls method `25` on the server.</span>
+
+<code>**async def complete_post_object**(param: [DataStoreCompletePostParam](#datastorecompletepostparam)) -> None</code><br>
+<span class="docs">Calls method `26` on the server.</span>
+
+<code>**async def get_new_arrived_notifications**(param: [DataStoreGetNewArrivedNotificationsParam](#datastoregetnewarrivednotificationsparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `27` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>result: list[[DataStoreNotification](#datastorenotification)]</code><br>
+<code>has_next: bool</code><br>
+</span>
+</span>
+
+<code>**async def get_specific_meta**(param: [DataStoreGetSpecificMetaParam](#datastoregetspecificmetaparam)) -> list[[DataStoreSpecificMetaInfo](#datastorespecificmetainfo)]</code><br>
+<span class="docs">Calls method `28` on the server.</span>
+
+<code>**async def get_persistence_info**(owner_id: int, slot_id: int) -> [DataStorePersistenceInfo](#datastorepersistenceinfo)</code><br>
+<span class="docs">Calls method `29` on the server.</span>
+
+<code>**async def get_persistence_infos**(owner_id: int, slot_ids: list[int]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `30` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStorePersistenceInfo](#datastorepersistenceinfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def perpetuate_object**(persistence_slot_id: int, data_id: int, delete_last_object: bool) -> None</code><br>
+<span class="docs">Calls method `31` on the server.</span>
+
+<code>**async def unperpetuate_object**(persistence_slot_id: int, delete_last_object: bool) -> None</code><br>
+<span class="docs">Calls method `32` on the server.</span>
+
+<code>**async def prepare_get_object_or_meta_binary**(param: [DataStorePrepareGetParam](#datastorepreparegetparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `33` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>get_info: [DataStoreReqGetInfo](#datastorereqgetinfo)</code><br>
+<code>additional_meta: [DataStoreReqGetAdditionalMeta](#datastorereqgetadditionalmeta)</code><br>
+</span>
+</span>
+
+<code>**async def get_password_info**(data_id: int) -> [DataStorePasswordInfo](#datastorepasswordinfo)</code><br>
+<span class="docs">Calls method `34` on the server.</span>
+
+<code>**async def get_password_infos**(data_ids: list[int]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `35` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStorePasswordInfo](#datastorepasswordinfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def get_metas_multiple_param**(params: list[[DataStoreGetMetaParam](#datastoregetmetaparam)]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `36` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStoreMetaInfo](#datastoremetainfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def complete_post_objects**(data_ids: list[int]) -> None</code><br>
+<span class="docs">Calls method `37` on the server.</span>
+
+<code>**async def change_meta**(param: [DataStoreChangeMetaParam](#datastorechangemetaparam)) -> None</code><br>
+<span class="docs">Calls method `38` on the server.</span>
+
+<code>**async def change_metas**(data_ids: list[int], param: list[[DataStoreChangeMetaParam](#datastorechangemetaparam)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Calls method `39` on the server.</span>
+
+<code>**async def rate_objects**(targets: list[[DataStoreRatingTarget](#datastoreratingtarget)], param: list[[DataStoreRateObjectParam](#datastorerateobjectparam)], transactional: bool, fetch_ratings: bool) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `40` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStoreRatingInfo](#datastoreratinginfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def post_meta_binary_with_data_id**(data_id: int, param: [DataStorePreparePostParam](#datastorepreparepostparam)) -> None</code><br>
+<span class="docs">Calls method `41` on the server.</span>
+
+<code>**async def post_meta_binaries_with_data_id**(data_ids: list[int], param: list[[DataStorePreparePostParam](#datastorepreparepostparam)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Calls method `42` on the server.</span>
+
+<code>**async def rate_object_with_posting**(target: [DataStoreRatingTarget](#datastoreratingtarget), rate_param: [DataStoreRateObjectParam](#datastorerateobjectparam), post_param: [DataStorePreparePostParam](#datastorepreparepostparam), fetch_ratings: bool) -> [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<span class="docs">Calls method `43` on the server.</span>
+
+<code>**async def rate_objects_with_posting**(targets: list[[DataStoreRatingTarget](#datastoreratingtarget)], rate_param: list[[DataStoreRateObjectParam](#datastorerateobjectparam)], post_param: list[[DataStorePreparePostParam](#datastorepreparepostparam)], transactional: bool, fetch_ratings: bool) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `44` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>ratings: list[[DataStoreRatingInfo](#datastoreratinginfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def get_object_infos**(data_ids: list[int]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Calls method `45` on the server. The RMC response has the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStoreReqGetInfo](#datastorereqgetinfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def search_object_light**(param: [DataStoreSearchParam](#datastoresearchparam)) -> [DataStoreSearchResult](#datastoresearchresult)</code><br>
+<span class="docs">Calls method `46` on the server.</span>
+
+<code>**async def search_mii**(param: [MiiTubeSearchParam](#miitubesearchparam)) -> [MiiTubeSearchResult](#miitubesearchresult)</code><br>
+<span class="docs">Calls method `47` on the server.</span>
+
+## DataStore_MiitopiaServer3DS
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new [`DataStore_MiitopiaServer3DS`](#datastore_miitopiaserver3ds).</span>
+
+<code>**async def logout**(client: [RMCClient](rmc.md#rmcclient)) -> None</code><br>
+<span class="docs">Called whenever a client is disconnected. May be overridden by a subclass.</span>
+
+<code>**async def prepare_get_object_v1**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePrepareGetParamV1](#datastorepreparegetparamv1)) -> [DataStoreReqGetInfoV1](#datastorereqgetinfov1)</code><br>
+<span class="docs">Handler for method `1`. This method should be overridden by a subclass.</span>
+
+<code>**async def prepare_post_object_v1**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePreparePostParamV1](#datastorepreparepostparamv1)) -> [DataStoreReqPostInfoV1](#datastorereqpostinfov1)</code><br>
+<span class="docs">Handler for method `2`. This method should be overridden by a subclass.</span>
+
+<code>**async def complete_post_object_v1**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreCompletePostParamV1](#datastorecompletepostparamv1)) -> None</code><br>
+<span class="docs">Handler for method `3`. This method should be overridden by a subclass.</span>
+
+<code>**async def delete_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreDeleteParam](#datastoredeleteparam)) -> None</code><br>
+<span class="docs">Handler for method `4`. This method should be overridden by a subclass.</span>
+
+<code>**async def delete_objects**(client: [RMCClient](rmc.md#rmcclient), param: list[[DataStoreDeleteParam](#datastoredeleteparam)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Handler for method `5`. This method should be overridden by a subclass.</span>
+
+<code>**async def change_meta_v1**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreChangeMetaParamV1](#datastorechangemetaparamv1)) -> None</code><br>
+<span class="docs">Handler for method `6`. This method should be overridden by a subclass.</span>
+
+<code>**async def change_metas_v1**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int], param: list[[DataStoreChangeMetaParamV1](#datastorechangemetaparamv1)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Handler for method `7`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_meta**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreGetMetaParam](#datastoregetmetaparam)) -> [DataStoreMetaInfo](#datastoremetainfo)</code><br>
+<span class="docs">Handler for method `8`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_metas**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int], param: [DataStoreGetMetaParam](#datastoregetmetaparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `9`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>info: list[[DataStoreMetaInfo](#datastoremetainfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def prepare_update_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePrepareUpdateParam](#datastoreprepareupdateparam)) -> [DataStoreReqUpdateInfo](#datastorerequpdateinfo)</code><br>
+<span class="docs">Handler for method `10`. This method should be overridden by a subclass.</span>
+
+<code>**async def complete_update_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreCompleteUpdateParam](#datastorecompleteupdateparam)) -> None</code><br>
+<span class="docs">Handler for method `11`. This method should be overridden by a subclass.</span>
+
+<code>**async def search_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreSearchParam](#datastoresearchparam)) -> [DataStoreSearchResult](#datastoresearchresult)</code><br>
+<span class="docs">Handler for method `12`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_notification_url**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreGetNotificationUrlParam](#datastoregetnotificationurlparam)) -> [DataStoreReqGetNotificationUrlInfo](#datastorereqgetnotificationurlinfo)</code><br>
+<span class="docs">Handler for method `13`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_new_arrived_notifications_v1**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreGetNewArrivedNotificationsParam](#datastoregetnewarrivednotificationsparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `14`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>result: list[[DataStoreNotificationV1](#datastorenotificationv1)]</code><br>
+<code>has_next: bool</code><br>
+</span>
+</span>
+
+<code>**async def rate_object**(client: [RMCClient](rmc.md#rmcclient), target: [DataStoreRatingTarget](#datastoreratingtarget), param: [DataStoreRateObjectParam](#datastorerateobjectparam), fetch_ratings: bool) -> [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<span class="docs">Handler for method `15`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_rating**(client: [RMCClient](rmc.md#rmcclient), target: [DataStoreRatingTarget](#datastoreratingtarget), access_password: int) -> [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<span class="docs">Handler for method `16`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_ratings**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int], access_password: int) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `17`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>ratings: list[list[[DataStoreRatingInfoWithSlot](#datastoreratinginfowithslot)]]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def reset_rating**(client: [RMCClient](rmc.md#rmcclient), target: [DataStoreRatingTarget](#datastoreratingtarget), update_password: int) -> None</code><br>
+<span class="docs">Handler for method `18`. This method should be overridden by a subclass.</span>
+
+<code>**async def reset_ratings**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Handler for method `19`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_specific_meta_v1**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreGetSpecificMetaParamV1](#datastoregetspecificmetaparamv1)) -> list[[DataStoreSpecificMetaInfoV1](#datastorespecificmetainfov1)]</code><br>
+<span class="docs">Handler for method `20`. This method should be overridden by a subclass.</span>
+
+<code>**async def post_meta_binary**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePreparePostParam](#datastorepreparepostparam)) -> int</code><br>
+<span class="docs">Handler for method `21`. This method should be overridden by a subclass.</span>
+
+<code>**async def touch_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreTouchObjectParam](#datastoretouchobjectparam)) -> None</code><br>
+<span class="docs">Handler for method `22`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_rating_with_log**(client: [RMCClient](rmc.md#rmcclient), target: [DataStoreRatingTarget](#datastoreratingtarget), access_password: int) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `23`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>rating: [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<code>log: [DataStoreRatingLog](#datastoreratinglog)</code><br>
+</span>
+</span>
+
+<code>**async def prepare_post_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePreparePostParam](#datastorepreparepostparam)) -> [DataStoreReqPostInfo](#datastorereqpostinfo)</code><br>
+<span class="docs">Handler for method `24`. This method should be overridden by a subclass.</span>
+
+<code>**async def prepare_get_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePrepareGetParam](#datastorepreparegetparam)) -> [DataStoreReqGetInfo](#datastorereqgetinfo)</code><br>
+<span class="docs">Handler for method `25`. This method should be overridden by a subclass.</span>
+
+<code>**async def complete_post_object**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreCompletePostParam](#datastorecompletepostparam)) -> None</code><br>
+<span class="docs">Handler for method `26`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_new_arrived_notifications**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreGetNewArrivedNotificationsParam](#datastoregetnewarrivednotificationsparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `27`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>result: list[[DataStoreNotification](#datastorenotification)]</code><br>
+<code>has_next: bool</code><br>
+</span>
+</span>
+
+<code>**async def get_specific_meta**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreGetSpecificMetaParam](#datastoregetspecificmetaparam)) -> list[[DataStoreSpecificMetaInfo](#datastorespecificmetainfo)]</code><br>
+<span class="docs">Handler for method `28`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_persistence_info**(client: [RMCClient](rmc.md#rmcclient), owner_id: int, slot_id: int) -> [DataStorePersistenceInfo](#datastorepersistenceinfo)</code><br>
+<span class="docs">Handler for method `29`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_persistence_infos**(client: [RMCClient](rmc.md#rmcclient), owner_id: int, slot_ids: list[int]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `30`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStorePersistenceInfo](#datastorepersistenceinfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def perpetuate_object**(client: [RMCClient](rmc.md#rmcclient), persistence_slot_id: int, data_id: int, delete_last_object: bool) -> None</code><br>
+<span class="docs">Handler for method `31`. This method should be overridden by a subclass.</span>
+
+<code>**async def unperpetuate_object**(client: [RMCClient](rmc.md#rmcclient), persistence_slot_id: int, delete_last_object: bool) -> None</code><br>
+<span class="docs">Handler for method `32`. This method should be overridden by a subclass.</span>
+
+<code>**async def prepare_get_object_or_meta_binary**(client: [RMCClient](rmc.md#rmcclient), param: [DataStorePrepareGetParam](#datastorepreparegetparam)) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `33`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>get_info: [DataStoreReqGetInfo](#datastorereqgetinfo)</code><br>
+<code>additional_meta: [DataStoreReqGetAdditionalMeta](#datastorereqgetadditionalmeta)</code><br>
+</span>
+</span>
+
+<code>**async def get_password_info**(client: [RMCClient](rmc.md#rmcclient), data_id: int) -> [DataStorePasswordInfo](#datastorepasswordinfo)</code><br>
+<span class="docs">Handler for method `34`. This method should be overridden by a subclass.</span>
+
+<code>**async def get_password_infos**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `35`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStorePasswordInfo](#datastorepasswordinfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def get_metas_multiple_param**(client: [RMCClient](rmc.md#rmcclient), params: list[[DataStoreGetMetaParam](#datastoregetmetaparam)]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `36`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStoreMetaInfo](#datastoremetainfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def complete_post_objects**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int]) -> None</code><br>
+<span class="docs">Handler for method `37`. This method should be overridden by a subclass.</span>
+
+<code>**async def change_meta**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreChangeMetaParam](#datastorechangemetaparam)) -> None</code><br>
+<span class="docs">Handler for method `38`. This method should be overridden by a subclass.</span>
+
+<code>**async def change_metas**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int], param: list[[DataStoreChangeMetaParam](#datastorechangemetaparam)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Handler for method `39`. This method should be overridden by a subclass.</span>
+
+<code>**async def rate_objects**(client: [RMCClient](rmc.md#rmcclient), targets: list[[DataStoreRatingTarget](#datastoreratingtarget)], param: list[[DataStoreRateObjectParam](#datastorerateobjectparam)], transactional: bool, fetch_ratings: bool) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `40`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStoreRatingInfo](#datastoreratinginfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def post_meta_binary_with_data_id**(client: [RMCClient](rmc.md#rmcclient), data_id: int, param: [DataStorePreparePostParam](#datastorepreparepostparam)) -> None</code><br>
+<span class="docs">Handler for method `41`. This method should be overridden by a subclass.</span>
+
+<code>**async def post_meta_binaries_with_data_id**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int], param: list[[DataStorePreparePostParam](#datastorepreparepostparam)], transactional: bool) -> list[[Result](common.md#result)]</code><br>
+<span class="docs">Handler for method `42`. This method should be overridden by a subclass.</span>
+
+<code>**async def rate_object_with_posting**(client: [RMCClient](rmc.md#rmcclient), target: [DataStoreRatingTarget](#datastoreratingtarget), rate_param: [DataStoreRateObjectParam](#datastorerateobjectparam), post_param: [DataStorePreparePostParam](#datastorepreparepostparam), fetch_ratings: bool) -> [DataStoreRatingInfo](#datastoreratinginfo)</code><br>
+<span class="docs">Handler for method `43`. This method should be overridden by a subclass.</span>
+
+<code>**async def rate_objects_with_posting**(client: [RMCClient](rmc.md#rmcclient), targets: list[[DataStoreRatingTarget](#datastoreratingtarget)], rate_param: list[[DataStoreRateObjectParam](#datastorerateobjectparam)], post_param: list[[DataStorePreparePostParam](#datastorepreparepostparam)], transactional: bool, fetch_ratings: bool) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `44`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>ratings: list[[DataStoreRatingInfo](#datastoreratinginfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def get_object_infos**(client: [RMCClient](rmc.md#rmcclient), data_ids: list[int]) -> [RMCResponse](common.md)</code><br>
+<span class="docs">Handler for method `45`. This method should be overridden by a subclass. The RMC response must have the following attributes:<br>
+<span class="docs">
+<code>infos: list[[DataStoreReqGetInfo](#datastorereqgetinfo)]</code><br>
+<code>results: list[[Result](common.md#result)]</code><br>
+</span>
+</span>
+
+<code>**async def search_object_light**(client: [RMCClient](rmc.md#rmcclient), param: [DataStoreSearchParam](#datastoresearchparam)) -> [DataStoreSearchResult](#datastoresearchresult)</code><br>
+<span class="docs">Handler for method `46`. This method should be overridden by a subclass.</span>
+
+<code>**async def search_mii**(client: [RMCClient](rmc.md#rmcclient), param: [MiiTubeSearchParam](#miitubesearchparam)) -> [MiiTubeSearchResult](#miitubesearchresult)</code><br>
+<span class="docs">Handler for method `47`. This method should be overridden by a subclass.</span>
+
+## Category
+This class defines the following constants:<br>
+<span class="docs">
+`SINGING = 0`<br>
+`SPORT = 1`<br>
+`ACTING = 2`<br>
+`COMEDY = 3`<br>
+`MUSIC = 4`<br>
+`MARTIAL_ARTS = 5`<br>
+`DANCING = 6`<br>
+`ADVENTURING = 7`<br>
+`FILM_DIRECTING = 8`<br>
+`COOKING = 9`<br>
+`CHATTING = 10`<br>
+`PUBLIC_SPEAKING = 11`<br>
+`CRAFTWORK = 12`<br>
+`DRAWING = 13`<br>
+`STUDYING = 14`<br>
+`WRITING = 15`<br>
+`FASHION = 16`<br>
+`DINING = 17`<br>
+`NOT_TELLING = 18`<br>
+`ANY = 255`<br>
+</span>
+
+## Gender
+This class defines the following constants:<br>
+<span class="docs">
+`MALE = 0`<br>
+`FEMALE = 1`<br>
+`ANY = 2`<br>
+</span>
+
+## DataStoreChangeMetaCompareParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreChangeMetaCompareParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>comparison_flag: int</code><br>
+<code>name: str</code><br>
+<code>permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>delete_permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>period: int</code><br>
+<code>meta_binary: bytes</code><br>
+<code>tags: list[str]</code><br>
+<code>referred_count: int</code><br>
+<code>data_type: int</code><br>
+<code>status: int</code><br>
+</span><br>
+
+## DataStoreChangeMetaParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreChangeMetaParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>modifies_flag: int</code><br>
+<code>name: str</code><br>
+<code>permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>delete_permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>period: int</code><br>
+<code>meta_binary: bytes</code><br>
+<code>tags: list[str]</code><br>
+<code>update_password: int</code><br>
+<code>referred_count: int</code><br>
+<code>data_type: int</code><br>
+<code>status: int</code><br>
+<code>compare_param: [DataStoreChangeMetaCompareParam](#datastorechangemetacompareparam) = [DataStoreChangeMetaCompareParam](#datastorechangemetacompareparam)()</code><br>
+<code>persistence_target: [DataStorePersistenceTarget](#datastorepersistencetarget) = [DataStorePersistenceTarget](#datastorepersistencetarget)()</code><br>
+</span><br>
+
+## DataStoreChangeMetaParamV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreChangeMetaParamV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>modifies_flag: int</code><br>
+<code>name: str</code><br>
+<code>permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>delete_permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>period: int</code><br>
+<code>meta_binary: bytes</code><br>
+<code>tags: list[str]</code><br>
+<code>update_password: int</code><br>
+</span><br>
+
+## DataStoreCompletePostParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreCompletePostParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>success: bool</code><br>
+</span><br>
+
+## DataStoreCompletePostParamV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreCompletePostParamV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>success: bool</code><br>
+</span><br>
+
+## DataStoreCompleteUpdateParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreCompleteUpdateParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>version: int</code><br>
+<code>success: bool</code><br>
+</span><br>
+
+## DataStoreDeleteParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreDeleteParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>update_password: int</code><br>
+</span><br>
+
+## DataStoreGetMetaParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreGetMetaParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int = 0</code><br>
+<code>persistence_target: [DataStorePersistenceTarget](#datastorepersistencetarget) = [DataStorePersistenceTarget](#datastorepersistencetarget)()</code><br>
+<code>result_option: int = 0</code><br>
+<code>access_password: int = 0</code><br>
+</span><br>
+
+## DataStoreGetNewArrivedNotificationsParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreGetNewArrivedNotificationsParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>last_notification_id: int</code><br>
+<code>limit: int</code><br>
+</span><br>
+
+## DataStoreGetNotificationUrlParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreGetNotificationUrlParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>previous_url: str</code><br>
+</span><br>
+
+## DataStoreGetSpecificMetaParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreGetSpecificMetaParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_ids: list[int]</code><br>
+</span><br>
+
+## DataStoreGetSpecificMetaParamV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreGetSpecificMetaParamV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_ids: list[int]</code><br>
+</span><br>
+
+## DataStoreKeyValue
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreKeyValue` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>key: str</code><br>
+<code>value: str</code><br>
+</span><br>
+
+## DataStoreMetaInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreMetaInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>owner_id: int</code><br>
+<code>size: int</code><br>
+<code>name: str</code><br>
+<code>data_type: int</code><br>
+<code>meta_binary: bytes</code><br>
+<code>permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>delete_permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>create_time: [DateTime](common.md#datetime)</code><br>
+<code>update_time: [DateTime](common.md#datetime)</code><br>
+<code>period: int</code><br>
+<code>status: int</code><br>
+<code>referred_count: int</code><br>
+<code>refer_data_id: int</code><br>
+<code>flag: int</code><br>
+<code>referred_time: [DateTime](common.md#datetime)</code><br>
+<code>expire_time: [DateTime](common.md#datetime)</code><br>
+<code>tags: list[str]</code><br>
+<code>ratings: list[[DataStoreRatingInfoWithSlot](#datastoreratinginfowithslot)]</code><br>
+</span><br>
+
+## DataStoreNotification
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreNotification` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>notification_id: int</code><br>
+<code>data_id: int</code><br>
+</span><br>
+
+## DataStoreNotificationV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreNotificationV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>notification_id: int</code><br>
+<code>data_id: int</code><br>
+</span><br>
+
+## DataStorePasswordInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePasswordInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>access_password: int</code><br>
+<code>update_password: int</code><br>
+</span><br>
+
+## DataStorePermission
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePermission` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>permission: int = 3</code><br>
+<code>recipients: list[int] = []</code><br>
+</span><br>
+
+## DataStorePersistenceInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePersistenceInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>owner_id: int</code><br>
+<code>slot_id: int</code><br>
+<code>data_id: int</code><br>
+</span><br>
+
+## DataStorePersistenceInitParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePersistenceInitParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>persistence_id: int = 65535</code><br>
+<code>delete_last_object: bool = True</code><br>
+</span><br>
+
+## DataStorePersistenceTarget
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePersistenceTarget` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>owner_id: int = 0</code><br>
+<code>persistence_id: int = 65535</code><br>
+</span><br>
+
+## DataStorePrepareGetParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePrepareGetParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int = 0</code><br>
+<code>lock_id: int = 0</code><br>
+<code>persistence_target: [DataStorePersistenceTarget](#datastorepersistencetarget) = [DataStorePersistenceTarget](#datastorepersistencetarget)()</code><br>
+<code>access_password: int = 0</code><br>
+If `nex.version` >= 30500:<br>
+<span class="docs">
+<code>extra_data: list[str] = []</code><br>
+</span><br>
+</span><br>
+
+## DataStorePrepareGetParamV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePrepareGetParamV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>lock_id: int = 0</code><br>
+</span><br>
+
+## DataStorePreparePostParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePreparePostParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>size: int</code><br>
+<code>name: str</code><br>
+<code>data_type: int</code><br>
+<code>meta_binary: bytes</code><br>
+<code>permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>delete_permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>flag: int</code><br>
+<code>period: int</code><br>
+<code>refer_data_id: int = 0</code><br>
+<code>tags: list[str] = []</code><br>
+<code>rating_init_param: list[[DataStoreRatingInitParamWithSlot](#datastoreratinginitparamwithslot)] = []</code><br>
+<code>persistence_init_param: [DataStorePersistenceInitParam](#datastorepersistenceinitparam) = [DataStorePersistenceInitParam](#datastorepersistenceinitparam)()</code><br>
+If `nex.version` >= 30500:<br>
+<span class="docs">
+<code>extra_data: list[str]</code><br>
+</span><br>
+</span><br>
+
+## DataStorePreparePostParamV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePreparePostParamV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>size: int</code><br>
+<code>name: str</code><br>
+<code>data_type: int = 0</code><br>
+<code>meta_binary: bytes = b""</code><br>
+<code>permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>delete_permission: [DataStorePermission](#datastorepermission) = [DataStorePermission](#datastorepermission)()</code><br>
+<code>flag: int</code><br>
+<code>period: int</code><br>
+<code>refer_data_id: int = 0</code><br>
+<code>tags: list[str]</code><br>
+<code>rating_init_param: list[[DataStoreRatingInitParamWithSlot](#datastoreratinginitparamwithslot)]</code><br>
+</span><br>
+
+## DataStorePrepareUpdateParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStorePrepareUpdateParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>size: int</code><br>
+<code>update_password: int</code><br>
+<code>extra_data: list[str]</code><br>
+</span><br>
+
+## DataStoreRateObjectParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRateObjectParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>rating_value: int</code><br>
+<code>access_password: int</code><br>
+</span><br>
+
+## DataStoreRatingInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRatingInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>total_value: int</code><br>
+<code>count: int</code><br>
+<code>initial_value: int</code><br>
+</span><br>
+
+## DataStoreRatingInfoWithSlot
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRatingInfoWithSlot` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>slot: int</code><br>
+<code>info: [DataStoreRatingInfo](#datastoreratinginfo) = [DataStoreRatingInfo](#datastoreratinginfo)()</code><br>
+</span><br>
+
+## DataStoreRatingInitParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRatingInitParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>flag: int</code><br>
+<code>internal_flag: int</code><br>
+<code>lock_type: int</code><br>
+<code>initial_value: int</code><br>
+<code>range_min: int</code><br>
+<code>range_max: int</code><br>
+<code>period_hour: int</code><br>
+<code>period_duration: int</code><br>
+</span><br>
+
+## DataStoreRatingInitParamWithSlot
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRatingInitParamWithSlot` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>slot: int</code><br>
+<code>param: [DataStoreRatingInitParam](#datastoreratinginitparam) = [DataStoreRatingInitParam](#datastoreratinginitparam)()</code><br>
+</span><br>
+
+## DataStoreRatingLog
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRatingLog` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>is_rated: bool</code><br>
+<code>pid: int</code><br>
+<code>rating_value: int</code><br>
+<code>lock_expiration_time: [DateTime](common.md#datetime)</code><br>
+</span><br>
+
+## DataStoreRatingTarget
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreRatingTarget` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>slot: int</code><br>
+</span><br>
+
+## DataStoreReqGetAdditionalMeta
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqGetAdditionalMeta` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>owner_id: int</code><br>
+<code>data_type: int</code><br>
+<code>version: int</code><br>
+<code>meta_binary: bytes</code><br>
+</span><br>
+
+## DataStoreReqGetInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqGetInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>url: str</code><br>
+<code>headers: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>size: int</code><br>
+<code>root_ca_cert: bytes</code><br>
+If `nex.version` >= 30500:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+</span><br>
+</span><br>
+
+## DataStoreReqGetInfoV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqGetInfoV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>url: str</code><br>
+<code>headers: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>size: int</code><br>
+<code>root_ca_cert: bytes</code><br>
+</span><br>
+
+## DataStoreReqGetNotificationUrlInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqGetNotificationUrlInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>url: str</code><br>
+<code>key: str</code><br>
+<code>query: str</code><br>
+<code>root_ca_cert: bytes</code><br>
+</span><br>
+
+## DataStoreReqPostInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqPostInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>url: str</code><br>
+<code>headers: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>form: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>root_ca_cert: bytes</code><br>
+</span><br>
+
+## DataStoreReqPostInfoV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqPostInfoV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>url: str</code><br>
+<code>headers: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>form: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>root_ca_cert: bytes</code><br>
+</span><br>
+
+## DataStoreReqUpdateInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreReqUpdateInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>version: int</code><br>
+<code>url: str</code><br>
+<code>headers: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>form: list[[DataStoreKeyValue](#datastorekeyvalue)]</code><br>
+<code>root_ca_cert: bytes</code><br>
+</span><br>
+
+## DataStoreSearchParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreSearchParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>search_target: int = 1</code><br>
+<code>owner_ids: list[int] = []</code><br>
+<code>owner_type: int = 0</code><br>
+<code>destination_ids: list[int] = []</code><br>
+<code>data_type: int = 65535</code><br>
+<code>created_after: [DateTime](common.md#datetime) = [DateTime](common.md#datetime).future()</code><br>
+<code>created_before: [DateTime](common.md#datetime) = [DateTime](common.md#datetime).future()</code><br>
+<code>updated_after: [DateTime](common.md#datetime) = [DateTime](common.md#datetime).future()</code><br>
+<code>updated_before: [DateTime](common.md#datetime) = [DateTime](common.md#datetime).future()</code><br>
+<code>refer_data_id: int = 0</code><br>
+<code>tags: list[str] = []</code><br>
+<code>result_order_column: int = 0</code><br>
+<code>result_order: int = 0</code><br>
+<code>result_range: [ResultRange](common.md#resultrange) = [ResultRange](common.md#resultrange)()</code><br>
+<code>result_option: int = 0</code><br>
+<code>minimal_rating_frequency: int = 0</code><br>
+<code>use_cache: bool = False</code><br>
+<code>total_count_enabled: bool = True</code><br>
+<code>data_types: list[int] = []</code><br>
+</span><br>
+
+## DataStoreSearchResult
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreSearchResult` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>total_count: int</code><br>
+<code>result: list[[DataStoreMetaInfo](#datastoremetainfo)]</code><br>
+<code>total_count_type: int</code><br>
+</span><br>
+
+## DataStoreSpecificMetaInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreSpecificMetaInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>owner_id: int</code><br>
+<code>size: int</code><br>
+<code>data_type: int</code><br>
+<code>version: int</code><br>
+</span><br>
+
+## DataStoreSpecificMetaInfoV1
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreSpecificMetaInfoV1` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>owner_id: int</code><br>
+<code>size: int</code><br>
+<code>data_type: int</code><br>
+<code>version: int</code><br>
+</span><br>
+
+## DataStoreTouchObjectParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `DataStoreTouchObjectParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>data_id: int</code><br>
+<code>lock_id: int</code><br>
+<code>access_password: int</code><br>
+</span><br>
+
+## MiiTubeMiiInfo
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `MiiTubeMiiInfo` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>meta_info: [DataStoreMetaInfo](#datastoremetainfo) = [DataStoreMetaInfo](#datastoremetainfo)()</code><br>
+<code>category: int</code><br>
+<code>ranking_type: int</code><br>
+</span><br>
+
+## MiiTubeSearchParam
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `MiiTubeSearchParam` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>name: str</code><br>
+<code>page: int = 0</code><br>
+<code>category: int = 255</code><br>
+<code>gender: int = 2</code><br>
+<code>country: int</code><br>
+<code>search_type: int = 0</code><br>
+<code>result_option: int = 0</code><br>
+</span><br>
+
+## MiiTubeSearchResult
+<code>**def _\_init__**()</code><br>
+<span class="docs">Creates a new `MiiTubeSearchResult` instance. Required fields must be filled in manually.</span>
+
+The following fields are defined in this class:<br>
+<span class="docs">
+<code>result: list[[MiiTubeMiiInfo](#miitubemiiinfo)]</code><br>
+<code>count: int</code><br>
+<code>page: int</code><br>
+<code>has_next: bool</code><br>
+</span><br>
+

--- a/docs/reference/nex/datastore_miitopia_3ds.md
+++ b/docs/reference/nex/datastore_miitopia_3ds.md
@@ -1,13 +1,13 @@
 
 # Module: <code>nintendo.nex.datastore_miitopia_3ds</code>
 
-Provides a client and server for the `DataStore_MiitopiaProtocol3DS`. This page was generated automatically from `datastore_miitopia_3ds.proto`.
+Provides a client and server for the `DataStoreProtocolMiitopia3DS`. This page was generated automatically from `datastore_miitopia_3ds.proto`.
 
-<code>**class** [DataStore_MiitopiaClient3DS](#datastore_miitopiaclient3ds)</code><br>
-<span class="docs">The client for the `DataStore_MiitopiaProtocol3DS`.</span>
+<code>**class** [DataStoreClientMiitopia3DS](#datastoreclientmiitopia3ds)</code><br>
+<span class="docs">The client for the `DataStoreProtocolMiitopia3DS`.</span>
 
-<code>**class** [DataStore_MiitopiaServer3DS](#datastore_miitopiaserver3ds)</code><br>
-<span class="docs">The server for the `DataStore_MiitopiaProtocol3DS`.</span>
+<code>**class** [DataStoreServerMiitopia3DS](#datastoreservermiitopia3ds)</code><br>
+<span class="docs">The server for the `DataStoreProtocolMiitopia3DS`.</span>
 
 <code>**class** [Category](#category)</code><br>
 <code>**class** [Gender](#gender)</code><br>
@@ -61,9 +61,9 @@ Provides a client and server for the `DataStore_MiitopiaProtocol3DS`. This page 
 <code>**class** [MiiTubeSearchParam](#miitubesearchparam)([Structure](common.md))</code><br>
 <code>**class** [MiiTubeSearchResult](#miitubesearchresult)([Structure](common.md))</code><br>
 
-## DataStore_MiitopiaClient3DS
+## DataStoreClientMiitopia3DS
 <code>**def _\_init__**(client: [RMCClient](rmc.md#rmcclient) / [HppClient](hpp.md#hppclient))</code><br>
-<span class="docs">Creates a new [`DataStore_MiitopiaClient3DS`](#datastore_miitopiaclient3ds).</span>
+<span class="docs">Creates a new [`DataStoreClientMiitopia3DS`](#datastoreclientmiitopia3ds).</span>
 
 <code>**async def prepare_get_object_v1**(param: [DataStorePrepareGetParamV1](#datastorepreparegetparamv1)) -> [DataStoreReqGetInfoV1](#datastorereqgetinfov1)</code><br>
 <span class="docs">Calls method `1` on the server.</span>
@@ -266,9 +266,9 @@ Provides a client and server for the `DataStore_MiitopiaProtocol3DS`. This page 
 <code>**async def search_mii**(param: [MiiTubeSearchParam](#miitubesearchparam)) -> [MiiTubeSearchResult](#miitubesearchresult)</code><br>
 <span class="docs">Calls method `47` on the server.</span>
 
-## DataStore_MiitopiaServer3DS
+## DataStoreServerMiitopia3DS
 <code>**def _\_init__**()</code><br>
-<span class="docs">Creates a new [`DataStore_MiitopiaServer3DS`](#datastore_miitopiaserver3ds).</span>
+<span class="docs">Creates a new [`DataStoreServerMiitopia3DS`](#datastoreservermiitopia3ds).</span>
 
 <code>**async def logout**(client: [RMCClient](rmc.md#rmcclient)) -> None</code><br>
 <span class="docs">Called whenever a client is disconnected. May be overridden by a subclass.</span>

--- a/nintendo/files/proto/datastore_miitopia_3ds.proto
+++ b/nintendo/files/proto/datastore_miitopia_3ds.proto
@@ -1,0 +1,66 @@
+
+import datastore;
+
+/*** Enums ***/
+
+enum Gender {
+	MALE = 0,
+	FEMALE = 1,
+
+	ANY = 2
+}
+
+enum Category {
+	SINGING = 0,
+	SPORT = 1,
+	ACTING = 2,
+	COMEDY = 3,
+	MUSIC = 4,
+	MARTIAL_ARTS = 5,
+	DANCING = 6,
+	ADVENTURING = 7,
+	FILM_DIRECTING = 8,
+	COOKING = 9,
+	CHATTING = 10,
+	PUBLIC_SPEAKING = 11,
+	CRAFTWORK = 12,
+	DRAWING = 13,
+	STUDYING = 14,
+	WRITING = 15,
+	FASHION = 16,
+	DINING = 17,
+	NOT_TELLING = 18,
+
+	ANY = 0xFF
+}
+
+/*** Method parameters ***/
+
+struct MiiTubeSearchParam {
+	string name;
+	uint32 page = 0;
+	uint8 category = 0xFF;
+	uint8 gender = 2;
+	uint8 country;
+	uint8 search_type = 0;
+	uint8 result_option = 0;
+}
+
+struct MiiTubeMiiInfo {
+	DataStoreMetaInfo meta_info;
+	uint8 category;
+	uint8 ranking_type;
+}
+
+struct MiiTubeSearchResult {
+	list<MiiTubeMiiInfo> result;
+	uint32 count;
+	uint32 page;
+	bool has_next;
+}
+
+protocol DataStore_Miitopia_3DS : DataStore {
+	method(47) search_mii(MiiTubeSearchParam param) {
+		MiiTubeSearchResult search_result;
+	}
+}

--- a/nintendo/files/proto/datastore_miitopia_3ds.proto
+++ b/nintendo/files/proto/datastore_miitopia_3ds.proto
@@ -59,7 +59,7 @@ struct MiiTubeSearchResult {
 	bool has_next;
 }
 
-protocol DataStore_Miitopia_3DS : DataStore {
+protocol DataStore_Miitopia3DS : DataStore {
 	method(47) search_mii(MiiTubeSearchParam param) {
 		MiiTubeSearchResult search_result;
 	}

--- a/nintendo/nex/datastore_miitopia_3ds.py
+++ b/nintendo/nex/datastore_miitopia_3ds.py
@@ -1,0 +1,3022 @@
+
+# This file was generated automatically by generate_protocols.py
+
+from nintendo.nex import notification, rmc, common, streams
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class Gender:
+	MALE = 0
+	FEMALE = 1
+	ANY = 2
+
+
+class Category:
+	SINGING = 0
+	SPORT = 1
+	ACTING = 2
+	COMEDY = 3
+	MUSIC = 4
+	MARTIAL_ARTS = 5
+	DANCING = 6
+	ADVENTURING = 7
+	FILM_DIRECTING = 8
+	COOKING = 9
+	CHATTING = 10
+	PUBLIC_SPEAKING = 11
+	CRAFTWORK = 12
+	DRAWING = 13
+	STUDYING = 14
+	WRITING = 15
+	FASHION = 16
+	DINING = 17
+	NOT_TELLING = 18
+	ANY = 255
+
+
+class DataStoreChangeMetaCompareParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.comparison_flag = None
+		self.name = None
+		self.permission = DataStorePermission()
+		self.delete_permission = DataStorePermission()
+		self.period = None
+		self.meta_binary = None
+		self.tags = None
+		self.referred_count = None
+		self.data_type = None
+		self.status = None
+	
+	def check_required(self, settings, version):
+		for field in ['comparison_flag', 'name', 'period', 'meta_binary', 'tags', 'referred_count', 'data_type', 'status']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.comparison_flag = stream.u32()
+		self.name = stream.string()
+		self.permission = stream.extract(DataStorePermission)
+		self.delete_permission = stream.extract(DataStorePermission)
+		self.period = stream.u16()
+		self.meta_binary = stream.qbuffer()
+		self.tags = stream.list(stream.string)
+		self.referred_count = stream.u32()
+		self.data_type = stream.u16()
+		self.status = stream.u8()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.comparison_flag)
+		stream.string(self.name)
+		stream.add(self.permission)
+		stream.add(self.delete_permission)
+		stream.u16(self.period)
+		stream.qbuffer(self.meta_binary)
+		stream.list(self.tags, stream.string)
+		stream.u32(self.referred_count)
+		stream.u16(self.data_type)
+		stream.u8(self.status)
+
+
+class DataStoreChangeMetaParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.modifies_flag = None
+		self.name = None
+		self.permission = DataStorePermission()
+		self.delete_permission = DataStorePermission()
+		self.period = None
+		self.meta_binary = None
+		self.tags = None
+		self.update_password = None
+		self.referred_count = None
+		self.data_type = None
+		self.status = None
+		self.compare_param = DataStoreChangeMetaCompareParam()
+		self.persistence_target = DataStorePersistenceTarget()
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'modifies_flag', 'name', 'period', 'meta_binary', 'tags', 'update_password', 'referred_count', 'data_type', 'status']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.modifies_flag = stream.u32()
+		self.name = stream.string()
+		self.permission = stream.extract(DataStorePermission)
+		self.delete_permission = stream.extract(DataStorePermission)
+		self.period = stream.u16()
+		self.meta_binary = stream.qbuffer()
+		self.tags = stream.list(stream.string)
+		self.update_password = stream.u64()
+		self.referred_count = stream.u32()
+		self.data_type = stream.u16()
+		self.status = stream.u8()
+		self.compare_param = stream.extract(DataStoreChangeMetaCompareParam)
+		self.persistence_target = stream.extract(DataStorePersistenceTarget)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u32(self.modifies_flag)
+		stream.string(self.name)
+		stream.add(self.permission)
+		stream.add(self.delete_permission)
+		stream.u16(self.period)
+		stream.qbuffer(self.meta_binary)
+		stream.list(self.tags, stream.string)
+		stream.u64(self.update_password)
+		stream.u32(self.referred_count)
+		stream.u16(self.data_type)
+		stream.u8(self.status)
+		stream.add(self.compare_param)
+		stream.add(self.persistence_target)
+
+
+class DataStoreChangeMetaParamV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.modifies_flag = None
+		self.name = None
+		self.permission = DataStorePermission()
+		self.delete_permission = DataStorePermission()
+		self.period = None
+		self.meta_binary = None
+		self.tags = None
+		self.update_password = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'modifies_flag', 'name', 'period', 'meta_binary', 'tags', 'update_password']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.modifies_flag = stream.u32()
+		self.name = stream.string()
+		self.permission = stream.extract(DataStorePermission)
+		self.delete_permission = stream.extract(DataStorePermission)
+		self.period = stream.u16()
+		self.meta_binary = stream.qbuffer()
+		self.tags = stream.list(stream.string)
+		self.update_password = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u32(self.modifies_flag)
+		stream.string(self.name)
+		stream.add(self.permission)
+		stream.add(self.delete_permission)
+		stream.u16(self.period)
+		stream.qbuffer(self.meta_binary)
+		stream.list(self.tags, stream.string)
+		stream.u64(self.update_password)
+
+
+class DataStoreCompletePostParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.success = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'success']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.success = stream.bool()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.bool(self.success)
+
+
+class DataStoreCompletePostParamV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.success = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'success']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u32()
+		self.success = stream.bool()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.data_id)
+		stream.bool(self.success)
+
+
+class DataStoreCompleteUpdateParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.version = None
+		self.success = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'version', 'success']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.version = stream.u32()
+		self.success = stream.bool()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u32(self.version)
+		stream.bool(self.success)
+
+
+class DataStoreDeleteParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.update_password = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'update_password']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.update_password = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u64(self.update_password)
+
+
+class DataStoreGetMetaParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = 0
+		self.persistence_target = DataStorePersistenceTarget()
+		self.result_option = 0
+		self.access_password = 0
+	
+	def check_required(self, settings, version):
+		pass
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.persistence_target = stream.extract(DataStorePersistenceTarget)
+		self.result_option = stream.u8()
+		self.access_password = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.add(self.persistence_target)
+		stream.u8(self.result_option)
+		stream.u64(self.access_password)
+
+
+class DataStoreGetNewArrivedNotificationsParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.last_notification_id = None
+		self.limit = None
+	
+	def check_required(self, settings, version):
+		for field in ['last_notification_id', 'limit']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.last_notification_id = stream.u64()
+		self.limit = stream.u16()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.last_notification_id)
+		stream.u16(self.limit)
+
+
+class DataStoreGetNotificationUrlParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.previous_url = None
+	
+	def check_required(self, settings, version):
+		for field in ['previous_url']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.previous_url = stream.string()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.string(self.previous_url)
+
+
+class DataStoreGetSpecificMetaParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_ids = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_ids']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_ids = stream.list(stream.u64)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.list(self.data_ids, stream.u64)
+
+
+class DataStoreGetSpecificMetaParamV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_ids = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_ids']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_ids = stream.list(stream.u32)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.list(self.data_ids, stream.u32)
+
+
+class DataStoreKeyValue(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.key = None
+		self.value = None
+	
+	def check_required(self, settings, version):
+		for field in ['key', 'value']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.key = stream.string()
+		self.value = stream.string()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.string(self.key)
+		stream.string(self.value)
+
+
+class DataStoreMetaInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.owner_id = None
+		self.size = None
+		self.name = None
+		self.data_type = None
+		self.meta_binary = None
+		self.permission = DataStorePermission()
+		self.delete_permission = DataStorePermission()
+		self.create_time = None
+		self.update_time = None
+		self.period = None
+		self.status = None
+		self.referred_count = None
+		self.refer_data_id = None
+		self.flag = None
+		self.referred_time = None
+		self.expire_time = None
+		self.tags = None
+		self.ratings = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'owner_id', 'size', 'name', 'data_type', 'meta_binary', 'create_time', 'update_time', 'period', 'status', 'referred_count', 'refer_data_id', 'flag', 'referred_time', 'expire_time', 'tags', 'ratings']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.owner_id = stream.pid()
+		self.size = stream.u32()
+		self.name = stream.string()
+		self.data_type = stream.u16()
+		self.meta_binary = stream.qbuffer()
+		self.permission = stream.extract(DataStorePermission)
+		self.delete_permission = stream.extract(DataStorePermission)
+		self.create_time = stream.datetime()
+		self.update_time = stream.datetime()
+		self.period = stream.u16()
+		self.status = stream.u8()
+		self.referred_count = stream.u32()
+		self.refer_data_id = stream.u32()
+		self.flag = stream.u32()
+		self.referred_time = stream.datetime()
+		self.expire_time = stream.datetime()
+		self.tags = stream.list(stream.string)
+		self.ratings = stream.list(DataStoreRatingInfoWithSlot)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.pid(self.owner_id)
+		stream.u32(self.size)
+		stream.string(self.name)
+		stream.u16(self.data_type)
+		stream.qbuffer(self.meta_binary)
+		stream.add(self.permission)
+		stream.add(self.delete_permission)
+		stream.datetime(self.create_time)
+		stream.datetime(self.update_time)
+		stream.u16(self.period)
+		stream.u8(self.status)
+		stream.u32(self.referred_count)
+		stream.u32(self.refer_data_id)
+		stream.u32(self.flag)
+		stream.datetime(self.referred_time)
+		stream.datetime(self.expire_time)
+		stream.list(self.tags, stream.string)
+		stream.list(self.ratings, stream.add)
+
+
+class DataStoreNotification(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.notification_id = None
+		self.data_id = None
+	
+	def check_required(self, settings, version):
+		for field in ['notification_id', 'data_id']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.notification_id = stream.u64()
+		self.data_id = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.notification_id)
+		stream.u64(self.data_id)
+
+
+class DataStoreNotificationV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.notification_id = None
+		self.data_id = None
+	
+	def check_required(self, settings, version):
+		for field in ['notification_id', 'data_id']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.notification_id = stream.u64()
+		self.data_id = stream.u32()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.notification_id)
+		stream.u32(self.data_id)
+
+
+class DataStorePasswordInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.access_password = None
+		self.update_password = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'access_password', 'update_password']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.access_password = stream.u64()
+		self.update_password = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u64(self.access_password)
+		stream.u64(self.update_password)
+
+
+class DataStorePermission(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.permission = 3
+		self.recipients = []
+	
+	def check_required(self, settings, version):
+		pass
+	
+	def load(self, stream, version):
+		self.permission = stream.u8()
+		self.recipients = stream.list(stream.pid)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u8(self.permission)
+		stream.list(self.recipients, stream.pid)
+
+
+class DataStorePersistenceInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.owner_id = None
+		self.slot_id = None
+		self.data_id = None
+	
+	def check_required(self, settings, version):
+		for field in ['owner_id', 'slot_id', 'data_id']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.owner_id = stream.pid()
+		self.slot_id = stream.u16()
+		self.data_id = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.pid(self.owner_id)
+		stream.u16(self.slot_id)
+		stream.u64(self.data_id)
+
+
+class DataStorePersistenceInitParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.persistence_id = 65535
+		self.delete_last_object = True
+	
+	def check_required(self, settings, version):
+		pass
+	
+	def load(self, stream, version):
+		self.persistence_id = stream.u16()
+		self.delete_last_object = stream.bool()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u16(self.persistence_id)
+		stream.bool(self.delete_last_object)
+
+
+class DataStorePersistenceTarget(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.owner_id = 0
+		self.persistence_id = 65535
+	
+	def check_required(self, settings, version):
+		pass
+	
+	def load(self, stream, version):
+		self.owner_id = stream.pid()
+		self.persistence_id = stream.u16()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.pid(self.owner_id)
+		stream.u16(self.persistence_id)
+
+
+class DataStorePrepareGetParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = 0
+		self.lock_id = 0
+		self.persistence_target = DataStorePersistenceTarget()
+		self.access_password = 0
+		self.extra_data = []
+	
+	def check_required(self, settings, version):
+		if settings["nex.version"] >= 30500:
+			pass
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.lock_id = stream.u32()
+		self.persistence_target = stream.extract(DataStorePersistenceTarget)
+		self.access_password = stream.u64()
+		if stream.settings["nex.version"] >= 30500:
+			self.extra_data = stream.list(stream.string)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u32(self.lock_id)
+		stream.add(self.persistence_target)
+		stream.u64(self.access_password)
+		if stream.settings["nex.version"] >= 30500:
+			stream.list(self.extra_data, stream.string)
+
+
+class DataStorePrepareGetParamV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.lock_id = 0
+	
+	def check_required(self, settings, version):
+		for field in ['data_id']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u32()
+		self.lock_id = stream.u32()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.data_id)
+		stream.u32(self.lock_id)
+
+
+class DataStorePreparePostParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.size = None
+		self.name = None
+		self.data_type = None
+		self.meta_binary = None
+		self.permission = DataStorePermission()
+		self.delete_permission = DataStorePermission()
+		self.flag = None
+		self.period = None
+		self.refer_data_id = 0
+		self.tags = []
+		self.rating_init_param = []
+		self.persistence_init_param = DataStorePersistenceInitParam()
+		self.extra_data = None
+	
+	def check_required(self, settings, version):
+		for field in ['size', 'name', 'data_type', 'meta_binary', 'flag', 'period']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+		if settings["nex.version"] >= 30500:
+			for field in ['extra_data']:
+				if getattr(self, field) is None:
+					raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.size = stream.u32()
+		self.name = stream.string()
+		self.data_type = stream.u16()
+		self.meta_binary = stream.qbuffer()
+		self.permission = stream.extract(DataStorePermission)
+		self.delete_permission = stream.extract(DataStorePermission)
+		self.flag = stream.u32()
+		self.period = stream.u16()
+		self.refer_data_id = stream.u32()
+		self.tags = stream.list(stream.string)
+		self.rating_init_param = stream.list(DataStoreRatingInitParamWithSlot)
+		self.persistence_init_param = stream.extract(DataStorePersistenceInitParam)
+		if stream.settings["nex.version"] >= 30500:
+			self.extra_data = stream.list(stream.string)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.size)
+		stream.string(self.name)
+		stream.u16(self.data_type)
+		stream.qbuffer(self.meta_binary)
+		stream.add(self.permission)
+		stream.add(self.delete_permission)
+		stream.u32(self.flag)
+		stream.u16(self.period)
+		stream.u32(self.refer_data_id)
+		stream.list(self.tags, stream.string)
+		stream.list(self.rating_init_param, stream.add)
+		stream.add(self.persistence_init_param)
+		if stream.settings["nex.version"] >= 30500:
+			stream.list(self.extra_data, stream.string)
+
+
+class DataStorePreparePostParamV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.size = None
+		self.name = None
+		self.data_type = 0
+		self.meta_binary = b""
+		self.permission = DataStorePermission()
+		self.delete_permission = DataStorePermission()
+		self.flag = None
+		self.period = None
+		self.refer_data_id = 0
+		self.tags = None
+		self.rating_init_param = None
+	
+	def check_required(self, settings, version):
+		for field in ['size', 'name', 'flag', 'period', 'tags', 'rating_init_param']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.size = stream.u32()
+		self.name = stream.string()
+		self.data_type = stream.u16()
+		self.meta_binary = stream.qbuffer()
+		self.permission = stream.extract(DataStorePermission)
+		self.delete_permission = stream.extract(DataStorePermission)
+		self.flag = stream.u32()
+		self.period = stream.u16()
+		self.refer_data_id = stream.u32()
+		self.tags = stream.list(stream.string)
+		self.rating_init_param = stream.list(DataStoreRatingInitParamWithSlot)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.size)
+		stream.string(self.name)
+		stream.u16(self.data_type)
+		stream.qbuffer(self.meta_binary)
+		stream.add(self.permission)
+		stream.add(self.delete_permission)
+		stream.u32(self.flag)
+		stream.u16(self.period)
+		stream.u32(self.refer_data_id)
+		stream.list(self.tags, stream.string)
+		stream.list(self.rating_init_param, stream.add)
+
+
+class DataStorePrepareUpdateParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.size = None
+		self.update_password = None
+		self.extra_data = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'size', 'update_password', 'extra_data']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.size = stream.u32()
+		self.update_password = stream.u64()
+		self.extra_data = stream.list(stream.string)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u32(self.size)
+		stream.u64(self.update_password)
+		stream.list(self.extra_data, stream.string)
+
+
+class DataStoreRateObjectParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.rating_value = None
+		self.access_password = None
+	
+	def check_required(self, settings, version):
+		for field in ['rating_value', 'access_password']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.rating_value = stream.s32()
+		self.access_password = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.s32(self.rating_value)
+		stream.u64(self.access_password)
+
+
+class DataStoreRatingInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.total_value = None
+		self.count = None
+		self.initial_value = None
+	
+	def check_required(self, settings, version):
+		for field in ['total_value', 'count', 'initial_value']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.total_value = stream.s64()
+		self.count = stream.u32()
+		self.initial_value = stream.s64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.s64(self.total_value)
+		stream.u32(self.count)
+		stream.s64(self.initial_value)
+
+
+class DataStoreRatingInfoWithSlot(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.slot = None
+		self.info = DataStoreRatingInfo()
+	
+	def check_required(self, settings, version):
+		for field in ['slot']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.slot = stream.u8()
+		self.info = stream.extract(DataStoreRatingInfo)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u8(self.slot)
+		stream.add(self.info)
+
+
+class DataStoreRatingInitParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.flag = None
+		self.internal_flag = None
+		self.lock_type = None
+		self.initial_value = None
+		self.range_min = None
+		self.range_max = None
+		self.period_hour = None
+		self.period_duration = None
+	
+	def check_required(self, settings, version):
+		for field in ['flag', 'internal_flag', 'lock_type', 'initial_value', 'range_min', 'range_max', 'period_hour', 'period_duration']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.flag = stream.u8()
+		self.internal_flag = stream.u8()
+		self.lock_type = stream.u8()
+		self.initial_value = stream.s64()
+		self.range_min = stream.s32()
+		self.range_max = stream.s32()
+		self.period_hour = stream.s8()
+		self.period_duration = stream.s16()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u8(self.flag)
+		stream.u8(self.internal_flag)
+		stream.u8(self.lock_type)
+		stream.s64(self.initial_value)
+		stream.s32(self.range_min)
+		stream.s32(self.range_max)
+		stream.s8(self.period_hour)
+		stream.s16(self.period_duration)
+
+
+class DataStoreRatingInitParamWithSlot(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.slot = None
+		self.param = DataStoreRatingInitParam()
+	
+	def check_required(self, settings, version):
+		for field in ['slot']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.slot = stream.s8()
+		self.param = stream.extract(DataStoreRatingInitParam)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.s8(self.slot)
+		stream.add(self.param)
+
+
+class DataStoreRatingLog(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.is_rated = None
+		self.pid = None
+		self.rating_value = None
+		self.lock_expiration_time = None
+	
+	def check_required(self, settings, version):
+		for field in ['is_rated', 'pid', 'rating_value', 'lock_expiration_time']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.is_rated = stream.bool()
+		self.pid = stream.pid()
+		self.rating_value = stream.s32()
+		self.lock_expiration_time = stream.datetime()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.bool(self.is_rated)
+		stream.pid(self.pid)
+		stream.s32(self.rating_value)
+		stream.datetime(self.lock_expiration_time)
+
+
+class DataStoreRatingTarget(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.slot = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'slot']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.slot = stream.s8()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.s8(self.slot)
+
+
+class DataStoreReqGetAdditionalMeta(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.owner_id = None
+		self.data_type = None
+		self.version = None
+		self.meta_binary = None
+	
+	def check_required(self, settings, version):
+		for field in ['owner_id', 'data_type', 'version', 'meta_binary']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.owner_id = stream.pid()
+		self.data_type = stream.u16()
+		self.version = stream.u16()
+		self.meta_binary = stream.qbuffer()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.pid(self.owner_id)
+		stream.u16(self.data_type)
+		stream.u16(self.version)
+		stream.qbuffer(self.meta_binary)
+
+
+class DataStoreReqGetInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.url = None
+		self.headers = None
+		self.size = None
+		self.root_ca_cert = None
+		self.data_id = None
+	
+	def check_required(self, settings, version):
+		for field in ['url', 'headers', 'size', 'root_ca_cert']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+		if settings["nex.version"] >= 30500:
+			for field in ['data_id']:
+				if getattr(self, field) is None:
+					raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.url = stream.string()
+		self.headers = stream.list(DataStoreKeyValue)
+		self.size = stream.u32()
+		self.root_ca_cert = stream.buffer()
+		if stream.settings["nex.version"] >= 30500:
+			self.data_id = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.string(self.url)
+		stream.list(self.headers, stream.add)
+		stream.u32(self.size)
+		stream.buffer(self.root_ca_cert)
+		if stream.settings["nex.version"] >= 30500:
+			stream.u64(self.data_id)
+
+
+class DataStoreReqGetInfoV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.url = None
+		self.headers = None
+		self.size = None
+		self.root_ca_cert = None
+	
+	def check_required(self, settings, version):
+		for field in ['url', 'headers', 'size', 'root_ca_cert']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.url = stream.string()
+		self.headers = stream.list(DataStoreKeyValue)
+		self.size = stream.u32()
+		self.root_ca_cert = stream.buffer()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.string(self.url)
+		stream.list(self.headers, stream.add)
+		stream.u32(self.size)
+		stream.buffer(self.root_ca_cert)
+
+
+class DataStoreReqGetNotificationUrlInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.url = None
+		self.key = None
+		self.query = None
+		self.root_ca_cert = None
+	
+	def check_required(self, settings, version):
+		for field in ['url', 'key', 'query', 'root_ca_cert']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.url = stream.string()
+		self.key = stream.string()
+		self.query = stream.string()
+		self.root_ca_cert = stream.buffer()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.string(self.url)
+		stream.string(self.key)
+		stream.string(self.query)
+		stream.buffer(self.root_ca_cert)
+
+
+class DataStoreReqPostInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.url = None
+		self.headers = None
+		self.form = None
+		self.root_ca_cert = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'url', 'headers', 'form', 'root_ca_cert']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.url = stream.string()
+		self.headers = stream.list(DataStoreKeyValue)
+		self.form = stream.list(DataStoreKeyValue)
+		self.root_ca_cert = stream.buffer()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.string(self.url)
+		stream.list(self.headers, stream.add)
+		stream.list(self.form, stream.add)
+		stream.buffer(self.root_ca_cert)
+
+
+class DataStoreReqPostInfoV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.url = None
+		self.headers = None
+		self.form = None
+		self.root_ca_cert = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'url', 'headers', 'form', 'root_ca_cert']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u32()
+		self.url = stream.string()
+		self.headers = stream.list(DataStoreKeyValue)
+		self.form = stream.list(DataStoreKeyValue)
+		self.root_ca_cert = stream.buffer()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.data_id)
+		stream.string(self.url)
+		stream.list(self.headers, stream.add)
+		stream.list(self.form, stream.add)
+		stream.buffer(self.root_ca_cert)
+
+
+class DataStoreReqUpdateInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.version = None
+		self.url = None
+		self.headers = None
+		self.form = None
+		self.root_ca_cert = None
+	
+	def check_required(self, settings, version):
+		for field in ['version', 'url', 'headers', 'form', 'root_ca_cert']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.version = stream.u32()
+		self.url = stream.string()
+		self.headers = stream.list(DataStoreKeyValue)
+		self.form = stream.list(DataStoreKeyValue)
+		self.root_ca_cert = stream.buffer()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.version)
+		stream.string(self.url)
+		stream.list(self.headers, stream.add)
+		stream.list(self.form, stream.add)
+		stream.buffer(self.root_ca_cert)
+
+
+class DataStoreSearchParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.search_target = 1
+		self.owner_ids = []
+		self.owner_type = 0
+		self.destination_ids = []
+		self.data_type = 65535
+		self.created_after = common.DateTime(671076024059)
+		self.created_before = common.DateTime(671076024059)
+		self.updated_after = common.DateTime(671076024059)
+		self.updated_before = common.DateTime(671076024059)
+		self.refer_data_id = 0
+		self.tags = []
+		self.result_order_column = 0
+		self.result_order = 0
+		self.result_range = common.ResultRange()
+		self.result_option = 0
+		self.minimal_rating_frequency = 0
+		self.use_cache = False
+		self.total_count_enabled = True
+		self.data_types = []
+	
+	def check_required(self, settings, version):
+		pass
+	
+	def load(self, stream, version):
+		self.search_target = stream.u8()
+		self.owner_ids = stream.list(stream.pid)
+		self.owner_type = stream.u8()
+		self.destination_ids = stream.list(stream.u64)
+		self.data_type = stream.u16()
+		self.created_after = stream.datetime()
+		self.created_before = stream.datetime()
+		self.updated_after = stream.datetime()
+		self.updated_before = stream.datetime()
+		self.refer_data_id = stream.u32()
+		self.tags = stream.list(stream.string)
+		self.result_order_column = stream.u8()
+		self.result_order = stream.u8()
+		self.result_range = stream.extract(common.ResultRange)
+		self.result_option = stream.u8()
+		self.minimal_rating_frequency = stream.u32()
+		self.use_cache = stream.bool()
+		self.total_count_enabled = stream.bool()
+		self.data_types = stream.list(stream.u16)
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u8(self.search_target)
+		stream.list(self.owner_ids, stream.pid)
+		stream.u8(self.owner_type)
+		stream.list(self.destination_ids, stream.u64)
+		stream.u16(self.data_type)
+		stream.datetime(self.created_after)
+		stream.datetime(self.created_before)
+		stream.datetime(self.updated_after)
+		stream.datetime(self.updated_before)
+		stream.u32(self.refer_data_id)
+		stream.list(self.tags, stream.string)
+		stream.u8(self.result_order_column)
+		stream.u8(self.result_order)
+		stream.add(self.result_range)
+		stream.u8(self.result_option)
+		stream.u32(self.minimal_rating_frequency)
+		stream.bool(self.use_cache)
+		stream.bool(self.total_count_enabled)
+		stream.list(self.data_types, stream.u16)
+
+
+class DataStoreSearchResult(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.total_count = None
+		self.result = None
+		self.total_count_type = None
+	
+	def check_required(self, settings, version):
+		for field in ['total_count', 'result', 'total_count_type']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.total_count = stream.u32()
+		self.result = stream.list(DataStoreMetaInfo)
+		self.total_count_type = stream.u8()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.total_count)
+		stream.list(self.result, stream.add)
+		stream.u8(self.total_count_type)
+
+
+class DataStoreSpecificMetaInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.owner_id = None
+		self.size = None
+		self.data_type = None
+		self.version = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'owner_id', 'size', 'data_type', 'version']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.owner_id = stream.pid()
+		self.size = stream.u32()
+		self.data_type = stream.u16()
+		self.version = stream.u32()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.pid(self.owner_id)
+		stream.u32(self.size)
+		stream.u16(self.data_type)
+		stream.u32(self.version)
+
+
+class DataStoreSpecificMetaInfoV1(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.owner_id = None
+		self.size = None
+		self.data_type = None
+		self.version = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'owner_id', 'size', 'data_type', 'version']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u32()
+		self.owner_id = stream.pid()
+		self.size = stream.u32()
+		self.data_type = stream.u16()
+		self.version = stream.u16()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u32(self.data_id)
+		stream.pid(self.owner_id)
+		stream.u32(self.size)
+		stream.u16(self.data_type)
+		stream.u16(self.version)
+
+
+class DataStoreTouchObjectParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.data_id = None
+		self.lock_id = None
+		self.access_password = None
+	
+	def check_required(self, settings, version):
+		for field in ['data_id', 'lock_id', 'access_password']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.data_id = stream.u64()
+		self.lock_id = stream.u32()
+		self.access_password = stream.u64()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.u64(self.data_id)
+		stream.u32(self.lock_id)
+		stream.u64(self.access_password)
+
+
+class MiiTubeSearchParam(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.name = None
+		self.page = 0
+		self.category = 255
+		self.gender = 2
+		self.country = None
+		self.search_type = 0
+		self.result_option = 0
+	
+	def check_required(self, settings, version):
+		for field in ['name', 'country']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.name = stream.string()
+		self.page = stream.u32()
+		self.category = stream.u8()
+		self.gender = stream.u8()
+		self.country = stream.u8()
+		self.search_type = stream.u8()
+		self.result_option = stream.u8()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.string(self.name)
+		stream.u32(self.page)
+		stream.u8(self.category)
+		stream.u8(self.gender)
+		stream.u8(self.country)
+		stream.u8(self.search_type)
+		stream.u8(self.result_option)
+
+
+class MiiTubeMiiInfo(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.meta_info = DataStoreMetaInfo()
+		self.category = None
+		self.ranking_type = None
+	
+	def check_required(self, settings, version):
+		for field in ['category', 'ranking_type']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.meta_info = stream.extract(DataStoreMetaInfo)
+		self.category = stream.u8()
+		self.ranking_type = stream.u8()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.add(self.meta_info)
+		stream.u8(self.category)
+		stream.u8(self.ranking_type)
+
+
+class MiiTubeSearchResult(common.Structure):
+	def __init__(self):
+		super().__init__()
+		self.result = None
+		self.count = None
+		self.page = None
+		self.has_next = None
+	
+	def check_required(self, settings, version):
+		for field in ['result', 'count', 'page', 'has_next']:
+			if getattr(self, field) is None:
+				raise ValueError("No value assigned to required field: %s" %field)
+	
+	def load(self, stream, version):
+		self.result = stream.list(MiiTubeMiiInfo)
+		self.count = stream.u32()
+		self.page = stream.u32()
+		self.has_next = stream.bool()
+	
+	def save(self, stream, version):
+		self.check_required(stream.settings, version)
+		stream.list(self.result, stream.add)
+		stream.u32(self.count)
+		stream.u32(self.page)
+		stream.bool(self.has_next)
+
+
+class DataStore_MiitopiaProtocol3DS:
+	METHOD_PREPARE_GET_OBJECT_V1 = 1
+	METHOD_PREPARE_POST_OBJECT_V1 = 2
+	METHOD_COMPLETE_POST_OBJECT_V1 = 3
+	METHOD_DELETE_OBJECT = 4
+	METHOD_DELETE_OBJECTS = 5
+	METHOD_CHANGE_META_V1 = 6
+	METHOD_CHANGE_METAS_V1 = 7
+	METHOD_GET_META = 8
+	METHOD_GET_METAS = 9
+	METHOD_PREPARE_UPDATE_OBJECT = 10
+	METHOD_COMPLETE_UPDATE_OBJECT = 11
+	METHOD_SEARCH_OBJECT = 12
+	METHOD_GET_NOTIFICATION_URL = 13
+	METHOD_GET_NEW_ARRIVED_NOTIFICATIONS_V1 = 14
+	METHOD_RATE_OBJECT = 15
+	METHOD_GET_RATING = 16
+	METHOD_GET_RATINGS = 17
+	METHOD_RESET_RATING = 18
+	METHOD_RESET_RATINGS = 19
+	METHOD_GET_SPECIFIC_META_V1 = 20
+	METHOD_POST_META_BINARY = 21
+	METHOD_TOUCH_OBJECT = 22
+	METHOD_GET_RATING_WITH_LOG = 23
+	METHOD_PREPARE_POST_OBJECT = 24
+	METHOD_PREPARE_GET_OBJECT = 25
+	METHOD_COMPLETE_POST_OBJECT = 26
+	METHOD_GET_NEW_ARRIVED_NOTIFICATIONS = 27
+	METHOD_GET_SPECIFIC_META = 28
+	METHOD_GET_PERSISTENCE_INFO = 29
+	METHOD_GET_PERSISTENCE_INFOS = 30
+	METHOD_PERPETUATE_OBJECT = 31
+	METHOD_UNPERPETUATE_OBJECT = 32
+	METHOD_PREPARE_GET_OBJECT_OR_META_BINARY = 33
+	METHOD_GET_PASSWORD_INFO = 34
+	METHOD_GET_PASSWORD_INFOS = 35
+	METHOD_GET_METAS_MULTIPLE_PARAM = 36
+	METHOD_COMPLETE_POST_OBJECTS = 37
+	METHOD_CHANGE_META = 38
+	METHOD_CHANGE_METAS = 39
+	METHOD_RATE_OBJECTS = 40
+	METHOD_POST_META_BINARY_WITH_DATA_ID = 41
+	METHOD_POST_META_BINARIES_WITH_DATA_ID = 42
+	METHOD_RATE_OBJECT_WITH_POSTING = 43
+	METHOD_RATE_OBJECTS_WITH_POSTING = 44
+	METHOD_GET_OBJECT_INFOS = 45
+	METHOD_SEARCH_OBJECT_LIGHT = 46
+	METHOD_SEARCH_MII = 47
+	
+	PROTOCOL_ID = 0x73
+
+
+class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
+	def __init__(self, client):
+		self.settings = client.settings
+		self.client = client
+	
+	async def prepare_get_object_v1(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PREPARE_GET_OBJECT_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreReqGetInfoV1)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_v1 -> done")
+		return info
+	
+	async def prepare_post_object_v1(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PREPARE_POST_OBJECT_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreReqPostInfoV1)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object_v1 -> done")
+		return info
+	
+	async def complete_post_object_v1(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.complete_post_object_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_COMPLETE_POST_OBJECT_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.complete_post_object_v1 -> done")
+	
+	async def delete_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.delete_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_DELETE_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.delete_object -> done")
+	
+	async def delete_objects(self, param, transactional):
+		logger.info("DataStore_MiitopiaClient3DS.delete_objects()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(param, stream.add)
+		stream.bool(transactional)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_DELETE_OBJECTS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.delete_objects -> done")
+		return results
+	
+	async def change_meta_v1(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.change_meta_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_CHANGE_META_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.change_meta_v1 -> done")
+	
+	async def change_metas_v1(self, data_ids, param, transactional):
+		logger.info("DataStore_MiitopiaClient3DS.change_metas_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		stream.list(param, stream.add)
+		stream.bool(transactional)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_CHANGE_METAS_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.change_metas_v1 -> done")
+		return results
+	
+	async def get_meta(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_meta()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_META, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreMetaInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_meta -> done")
+		return info
+	
+	async def get_metas(self, data_ids, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_metas()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_METAS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.info = stream.list(DataStoreMetaInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_metas -> done")
+		return obj
+	
+	async def prepare_update_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.prepare_update_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PREPARE_UPDATE_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreReqUpdateInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.prepare_update_object -> done")
+		return info
+	
+	async def complete_update_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.complete_update_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_COMPLETE_UPDATE_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.complete_update_object -> done")
+	
+	async def search_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.search_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_SEARCH_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		result = stream.extract(DataStoreSearchResult)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.search_object -> done")
+		return result
+	
+	async def get_notification_url(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_notification_url()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_NOTIFICATION_URL, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreReqGetNotificationUrlInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_notification_url -> done")
+		return info
+	
+	async def get_new_arrived_notifications_v1(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_NEW_ARRIVED_NOTIFICATIONS_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.result = stream.list(DataStoreNotificationV1)
+		obj.has_next = stream.bool()
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications_v1 -> done")
+		return obj
+	
+	async def rate_object(self, target, param, fetch_ratings):
+		logger.info("DataStore_MiitopiaClient3DS.rate_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(target)
+		stream.add(param)
+		stream.bool(fetch_ratings)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_RATE_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreRatingInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.rate_object -> done")
+		return info
+	
+	async def get_rating(self, target, access_password):
+		logger.info("DataStore_MiitopiaClient3DS.get_rating()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(target)
+		stream.u64(access_password)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_RATING, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		rating = stream.extract(DataStoreRatingInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_rating -> done")
+		return rating
+	
+	async def get_ratings(self, data_ids, access_password):
+		logger.info("DataStore_MiitopiaClient3DS.get_ratings()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		stream.u64(access_password)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_RATINGS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.ratings = stream.list(lambda: stream.list(DataStoreRatingInfoWithSlot))
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_ratings -> done")
+		return obj
+	
+	async def reset_rating(self, target, update_password):
+		logger.info("DataStore_MiitopiaClient3DS.reset_rating()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(target)
+		stream.u64(update_password)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_RESET_RATING, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.reset_rating -> done")
+	
+	async def reset_ratings(self, data_ids, transactional):
+		logger.info("DataStore_MiitopiaClient3DS.reset_ratings()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		stream.bool(transactional)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_RESET_RATINGS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.reset_ratings -> done")
+		return results
+	
+	async def get_specific_meta_v1(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta_v1()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_SPECIFIC_META_V1, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		infos = stream.list(DataStoreSpecificMetaInfoV1)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta_v1 -> done")
+		return infos
+	
+	async def post_meta_binary(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_POST_META_BINARY, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		data_id = stream.u64()
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary -> done")
+		return data_id
+	
+	async def touch_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.touch_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_TOUCH_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.touch_object -> done")
+	
+	async def get_rating_with_log(self, target, access_password):
+		logger.info("DataStore_MiitopiaClient3DS.get_rating_with_log()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(target)
+		stream.u64(access_password)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_RATING_WITH_LOG, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.rating = stream.extract(DataStoreRatingInfo)
+		obj.log = stream.extract(DataStoreRatingLog)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_rating_with_log -> done")
+		return obj
+	
+	async def prepare_post_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PREPARE_POST_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreReqPostInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object -> done")
+		return info
+	
+	async def prepare_get_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PREPARE_GET_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreReqGetInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object -> done")
+		return info
+	
+	async def complete_post_object(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.complete_post_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_COMPLETE_POST_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.complete_post_object -> done")
+	
+	async def get_new_arrived_notifications(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_NEW_ARRIVED_NOTIFICATIONS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.result = stream.list(DataStoreNotification)
+		obj.has_next = stream.bool()
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications -> done")
+		return obj
+	
+	async def get_specific_meta(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_SPECIFIC_META, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		infos = stream.list(DataStoreSpecificMetaInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta -> done")
+		return infos
+	
+	async def get_persistence_info(self, owner_id, slot_id):
+		logger.info("DataStore_MiitopiaClient3DS.get_persistence_info()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.pid(owner_id)
+		stream.u16(slot_id)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_PERSISTENCE_INFO, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStorePersistenceInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_persistence_info -> done")
+		return info
+	
+	async def get_persistence_infos(self, owner_id, slot_ids):
+		logger.info("DataStore_MiitopiaClient3DS.get_persistence_infos()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.pid(owner_id)
+		stream.list(slot_ids, stream.u16)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_PERSISTENCE_INFOS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.infos = stream.list(DataStorePersistenceInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_persistence_infos -> done")
+		return obj
+	
+	async def perpetuate_object(self, persistence_slot_id, data_id, delete_last_object):
+		logger.info("DataStore_MiitopiaClient3DS.perpetuate_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.u16(persistence_slot_id)
+		stream.u64(data_id)
+		stream.bool(delete_last_object)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PERPETUATE_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.perpetuate_object -> done")
+	
+	async def unperpetuate_object(self, persistence_slot_id, delete_last_object):
+		logger.info("DataStore_MiitopiaClient3DS.unperpetuate_object()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.u16(persistence_slot_id)
+		stream.bool(delete_last_object)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_UNPERPETUATE_OBJECT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.unperpetuate_object -> done")
+	
+	async def prepare_get_object_or_meta_binary(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_or_meta_binary()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_PREPARE_GET_OBJECT_OR_META_BINARY, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.get_info = stream.extract(DataStoreReqGetInfo)
+		obj.additional_meta = stream.extract(DataStoreReqGetAdditionalMeta)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_or_meta_binary -> done")
+		return obj
+	
+	async def get_password_info(self, data_id):
+		logger.info("DataStore_MiitopiaClient3DS.get_password_info()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.u64(data_id)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_PASSWORD_INFO, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStorePasswordInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_password_info -> done")
+		return info
+	
+	async def get_password_infos(self, data_ids):
+		logger.info("DataStore_MiitopiaClient3DS.get_password_infos()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_PASSWORD_INFOS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.infos = stream.list(DataStorePasswordInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_password_infos -> done")
+		return obj
+	
+	async def get_metas_multiple_param(self, params):
+		logger.info("DataStore_MiitopiaClient3DS.get_metas_multiple_param()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(params, stream.add)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_METAS_MULTIPLE_PARAM, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.infos = stream.list(DataStoreMetaInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_metas_multiple_param -> done")
+		return obj
+	
+	async def complete_post_objects(self, data_ids):
+		logger.info("DataStore_MiitopiaClient3DS.complete_post_objects()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_COMPLETE_POST_OBJECTS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.complete_post_objects -> done")
+	
+	async def change_meta(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.change_meta()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_CHANGE_META, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.change_meta -> done")
+	
+	async def change_metas(self, data_ids, param, transactional):
+		logger.info("DataStore_MiitopiaClient3DS.change_metas()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		stream.list(param, stream.add)
+		stream.bool(transactional)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_CHANGE_METAS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.change_metas -> done")
+		return results
+	
+	async def rate_objects(self, targets, param, transactional, fetch_ratings):
+		logger.info("DataStore_MiitopiaClient3DS.rate_objects()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(targets, stream.add)
+		stream.list(param, stream.add)
+		stream.bool(transactional)
+		stream.bool(fetch_ratings)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_RATE_OBJECTS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.infos = stream.list(DataStoreRatingInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.rate_objects -> done")
+		return obj
+	
+	async def post_meta_binary_with_data_id(self, data_id, param):
+		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary_with_data_id()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.u64(data_id)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_POST_META_BINARY_WITH_DATA_ID, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary_with_data_id -> done")
+	
+	async def post_meta_binaries_with_data_id(self, data_ids, param, transactional):
+		logger.info("DataStore_MiitopiaClient3DS.post_meta_binaries_with_data_id()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		stream.list(param, stream.add)
+		stream.bool(transactional)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_POST_META_BINARIES_WITH_DATA_ID, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.post_meta_binaries_with_data_id -> done")
+		return results
+	
+	async def rate_object_with_posting(self, target, rate_param, post_param, fetch_ratings):
+		logger.info("DataStore_MiitopiaClient3DS.rate_object_with_posting()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(target)
+		stream.add(rate_param)
+		stream.add(post_param)
+		stream.bool(fetch_ratings)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_RATE_OBJECT_WITH_POSTING, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		info = stream.extract(DataStoreRatingInfo)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.rate_object_with_posting -> done")
+		return info
+	
+	async def rate_objects_with_posting(self, targets, rate_param, post_param, transactional, fetch_ratings):
+		logger.info("DataStore_MiitopiaClient3DS.rate_objects_with_posting()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(targets, stream.add)
+		stream.list(rate_param, stream.add)
+		stream.list(post_param, stream.add)
+		stream.bool(transactional)
+		stream.bool(fetch_ratings)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_RATE_OBJECTS_WITH_POSTING, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.ratings = stream.list(DataStoreRatingInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.rate_objects_with_posting -> done")
+		return obj
+	
+	async def get_object_infos(self, data_ids):
+		logger.info("DataStore_MiitopiaClient3DS.get_object_infos()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.list(data_ids, stream.u64)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_GET_OBJECT_INFOS, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		obj = rmc.RMCResponse()
+		obj.infos = stream.list(DataStoreReqGetInfo)
+		obj.results = stream.list(stream.result)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.get_object_infos -> done")
+		return obj
+	
+	async def search_object_light(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.search_object_light()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_SEARCH_OBJECT_LIGHT, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		result = stream.extract(DataStoreSearchResult)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.search_object_light -> done")
+		return result
+	
+	async def search_mii(self, param):
+		logger.info("DataStore_MiitopiaClient3DS.search_mii()")
+		#--- request ---
+		stream = streams.StreamOut(self.settings)
+		stream.add(param)
+		data = await self.client.request(self.PROTOCOL_ID, self.METHOD_SEARCH_MII, stream.get())
+		
+		#--- response ---
+		stream = streams.StreamIn(data, self.settings)
+		search_result = stream.extract(MiiTubeSearchResult)
+		if not stream.eof():
+			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
+		logger.info("DataStore_MiitopiaClient3DS.search_mii -> done")
+		return search_result
+
+
+class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
+	def __init__(self):
+		self.methods = {
+			self.METHOD_PREPARE_GET_OBJECT_V1: self.handle_prepare_get_object_v1,
+			self.METHOD_PREPARE_POST_OBJECT_V1: self.handle_prepare_post_object_v1,
+			self.METHOD_COMPLETE_POST_OBJECT_V1: self.handle_complete_post_object_v1,
+			self.METHOD_DELETE_OBJECT: self.handle_delete_object,
+			self.METHOD_DELETE_OBJECTS: self.handle_delete_objects,
+			self.METHOD_CHANGE_META_V1: self.handle_change_meta_v1,
+			self.METHOD_CHANGE_METAS_V1: self.handle_change_metas_v1,
+			self.METHOD_GET_META: self.handle_get_meta,
+			self.METHOD_GET_METAS: self.handle_get_metas,
+			self.METHOD_PREPARE_UPDATE_OBJECT: self.handle_prepare_update_object,
+			self.METHOD_COMPLETE_UPDATE_OBJECT: self.handle_complete_update_object,
+			self.METHOD_SEARCH_OBJECT: self.handle_search_object,
+			self.METHOD_GET_NOTIFICATION_URL: self.handle_get_notification_url,
+			self.METHOD_GET_NEW_ARRIVED_NOTIFICATIONS_V1: self.handle_get_new_arrived_notifications_v1,
+			self.METHOD_RATE_OBJECT: self.handle_rate_object,
+			self.METHOD_GET_RATING: self.handle_get_rating,
+			self.METHOD_GET_RATINGS: self.handle_get_ratings,
+			self.METHOD_RESET_RATING: self.handle_reset_rating,
+			self.METHOD_RESET_RATINGS: self.handle_reset_ratings,
+			self.METHOD_GET_SPECIFIC_META_V1: self.handle_get_specific_meta_v1,
+			self.METHOD_POST_META_BINARY: self.handle_post_meta_binary,
+			self.METHOD_TOUCH_OBJECT: self.handle_touch_object,
+			self.METHOD_GET_RATING_WITH_LOG: self.handle_get_rating_with_log,
+			self.METHOD_PREPARE_POST_OBJECT: self.handle_prepare_post_object,
+			self.METHOD_PREPARE_GET_OBJECT: self.handle_prepare_get_object,
+			self.METHOD_COMPLETE_POST_OBJECT: self.handle_complete_post_object,
+			self.METHOD_GET_NEW_ARRIVED_NOTIFICATIONS: self.handle_get_new_arrived_notifications,
+			self.METHOD_GET_SPECIFIC_META: self.handle_get_specific_meta,
+			self.METHOD_GET_PERSISTENCE_INFO: self.handle_get_persistence_info,
+			self.METHOD_GET_PERSISTENCE_INFOS: self.handle_get_persistence_infos,
+			self.METHOD_PERPETUATE_OBJECT: self.handle_perpetuate_object,
+			self.METHOD_UNPERPETUATE_OBJECT: self.handle_unperpetuate_object,
+			self.METHOD_PREPARE_GET_OBJECT_OR_META_BINARY: self.handle_prepare_get_object_or_meta_binary,
+			self.METHOD_GET_PASSWORD_INFO: self.handle_get_password_info,
+			self.METHOD_GET_PASSWORD_INFOS: self.handle_get_password_infos,
+			self.METHOD_GET_METAS_MULTIPLE_PARAM: self.handle_get_metas_multiple_param,
+			self.METHOD_COMPLETE_POST_OBJECTS: self.handle_complete_post_objects,
+			self.METHOD_CHANGE_META: self.handle_change_meta,
+			self.METHOD_CHANGE_METAS: self.handle_change_metas,
+			self.METHOD_RATE_OBJECTS: self.handle_rate_objects,
+			self.METHOD_POST_META_BINARY_WITH_DATA_ID: self.handle_post_meta_binary_with_data_id,
+			self.METHOD_POST_META_BINARIES_WITH_DATA_ID: self.handle_post_meta_binaries_with_data_id,
+			self.METHOD_RATE_OBJECT_WITH_POSTING: self.handle_rate_object_with_posting,
+			self.METHOD_RATE_OBJECTS_WITH_POSTING: self.handle_rate_objects_with_posting,
+			self.METHOD_GET_OBJECT_INFOS: self.handle_get_object_infos,
+			self.METHOD_SEARCH_OBJECT_LIGHT: self.handle_search_object_light,
+			self.METHOD_SEARCH_MII: self.handle_search_mii,
+		}
+	
+	async def logout(self, client):
+		pass
+	
+	async def handle(self, client, method_id, input, output):
+		if method_id in self.methods:
+			await self.methods[method_id](client, input, output)
+		else:
+			logger.warning("Unknown method called on DataStore_MiitopiaServer3DS: %i", method_id)
+			raise common.RMCError("Core::NotImplemented")
+	
+	async def handle_prepare_get_object_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.prepare_get_object_v1()")
+		#--- request ---
+		param = input.extract(DataStorePrepareGetParamV1)
+		response = await self.prepare_get_object_v1(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreReqGetInfoV1):
+			raise RuntimeError("Expected DataStoreReqGetInfoV1, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_prepare_post_object_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.prepare_post_object_v1()")
+		#--- request ---
+		param = input.extract(DataStorePreparePostParamV1)
+		response = await self.prepare_post_object_v1(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreReqPostInfoV1):
+			raise RuntimeError("Expected DataStoreReqPostInfoV1, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_complete_post_object_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.complete_post_object_v1()")
+		#--- request ---
+		param = input.extract(DataStoreCompletePostParamV1)
+		await self.complete_post_object_v1(client, param)
+	
+	async def handle_delete_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.delete_object()")
+		#--- request ---
+		param = input.extract(DataStoreDeleteParam)
+		await self.delete_object(client, param)
+	
+	async def handle_delete_objects(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.delete_objects()")
+		#--- request ---
+		param = input.list(DataStoreDeleteParam)
+		transactional = input.bool()
+		response = await self.delete_objects(client, param, transactional)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.result)
+	
+	async def handle_change_meta_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.change_meta_v1()")
+		#--- request ---
+		param = input.extract(DataStoreChangeMetaParamV1)
+		await self.change_meta_v1(client, param)
+	
+	async def handle_change_metas_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.change_metas_v1()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		param = input.list(DataStoreChangeMetaParamV1)
+		transactional = input.bool()
+		response = await self.change_metas_v1(client, data_ids, param, transactional)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.result)
+	
+	async def handle_get_meta(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_meta()")
+		#--- request ---
+		param = input.extract(DataStoreGetMetaParam)
+		response = await self.get_meta(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreMetaInfo):
+			raise RuntimeError("Expected DataStoreMetaInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_metas(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_metas()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		param = input.extract(DataStoreGetMetaParam)
+		response = await self.get_metas(client, data_ids, param)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['info', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.info, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_prepare_update_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.prepare_update_object()")
+		#--- request ---
+		param = input.extract(DataStorePrepareUpdateParam)
+		response = await self.prepare_update_object(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreReqUpdateInfo):
+			raise RuntimeError("Expected DataStoreReqUpdateInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_complete_update_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.complete_update_object()")
+		#--- request ---
+		param = input.extract(DataStoreCompleteUpdateParam)
+		await self.complete_update_object(client, param)
+	
+	async def handle_search_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.search_object()")
+		#--- request ---
+		param = input.extract(DataStoreSearchParam)
+		response = await self.search_object(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreSearchResult):
+			raise RuntimeError("Expected DataStoreSearchResult, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_notification_url(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_notification_url()")
+		#--- request ---
+		param = input.extract(DataStoreGetNotificationUrlParam)
+		response = await self.get_notification_url(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreReqGetNotificationUrlInfo):
+			raise RuntimeError("Expected DataStoreReqGetNotificationUrlInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_new_arrived_notifications_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_new_arrived_notifications_v1()")
+		#--- request ---
+		param = input.extract(DataStoreGetNewArrivedNotificationsParam)
+		response = await self.get_new_arrived_notifications_v1(client, param)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['result', 'has_next']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.result, output.add)
+		output.bool(response.has_next)
+	
+	async def handle_rate_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.rate_object()")
+		#--- request ---
+		target = input.extract(DataStoreRatingTarget)
+		param = input.extract(DataStoreRateObjectParam)
+		fetch_ratings = input.bool()
+		response = await self.rate_object(client, target, param, fetch_ratings)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreRatingInfo):
+			raise RuntimeError("Expected DataStoreRatingInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_rating(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_rating()")
+		#--- request ---
+		target = input.extract(DataStoreRatingTarget)
+		access_password = input.u64()
+		response = await self.get_rating(client, target, access_password)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreRatingInfo):
+			raise RuntimeError("Expected DataStoreRatingInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_ratings(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_ratings()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		access_password = input.u64()
+		response = await self.get_ratings(client, data_ids, access_password)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['ratings', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.ratings, lambda x: output.list(x, output.add))
+		output.list(response.results, output.result)
+	
+	async def handle_reset_rating(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.reset_rating()")
+		#--- request ---
+		target = input.extract(DataStoreRatingTarget)
+		update_password = input.u64()
+		await self.reset_rating(client, target, update_password)
+	
+	async def handle_reset_ratings(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.reset_ratings()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		transactional = input.bool()
+		response = await self.reset_ratings(client, data_ids, transactional)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.result)
+	
+	async def handle_get_specific_meta_v1(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_specific_meta_v1()")
+		#--- request ---
+		param = input.extract(DataStoreGetSpecificMetaParamV1)
+		response = await self.get_specific_meta_v1(client, param)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.add)
+	
+	async def handle_post_meta_binary(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.post_meta_binary()")
+		#--- request ---
+		param = input.extract(DataStorePreparePostParam)
+		response = await self.post_meta_binary(client, param)
+		
+		#--- response ---
+		if not isinstance(response, int):
+			raise RuntimeError("Expected int, got %s" %response.__class__.__name__)
+		output.u64(response)
+	
+	async def handle_touch_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.touch_object()")
+		#--- request ---
+		param = input.extract(DataStoreTouchObjectParam)
+		await self.touch_object(client, param)
+	
+	async def handle_get_rating_with_log(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_rating_with_log()")
+		#--- request ---
+		target = input.extract(DataStoreRatingTarget)
+		access_password = input.u64()
+		response = await self.get_rating_with_log(client, target, access_password)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['rating', 'log']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.add(response.rating)
+		output.add(response.log)
+	
+	async def handle_prepare_post_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.prepare_post_object()")
+		#--- request ---
+		param = input.extract(DataStorePreparePostParam)
+		response = await self.prepare_post_object(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreReqPostInfo):
+			raise RuntimeError("Expected DataStoreReqPostInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_prepare_get_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.prepare_get_object()")
+		#--- request ---
+		param = input.extract(DataStorePrepareGetParam)
+		response = await self.prepare_get_object(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreReqGetInfo):
+			raise RuntimeError("Expected DataStoreReqGetInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_complete_post_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.complete_post_object()")
+		#--- request ---
+		param = input.extract(DataStoreCompletePostParam)
+		await self.complete_post_object(client, param)
+	
+	async def handle_get_new_arrived_notifications(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_new_arrived_notifications()")
+		#--- request ---
+		param = input.extract(DataStoreGetNewArrivedNotificationsParam)
+		response = await self.get_new_arrived_notifications(client, param)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['result', 'has_next']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.result, output.add)
+		output.bool(response.has_next)
+	
+	async def handle_get_specific_meta(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_specific_meta()")
+		#--- request ---
+		param = input.extract(DataStoreGetSpecificMetaParam)
+		response = await self.get_specific_meta(client, param)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.add)
+	
+	async def handle_get_persistence_info(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_persistence_info()")
+		#--- request ---
+		owner_id = input.pid()
+		slot_id = input.u16()
+		response = await self.get_persistence_info(client, owner_id, slot_id)
+		
+		#--- response ---
+		if not isinstance(response, DataStorePersistenceInfo):
+			raise RuntimeError("Expected DataStorePersistenceInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_persistence_infos(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_persistence_infos()")
+		#--- request ---
+		owner_id = input.pid()
+		slot_ids = input.list(input.u16)
+		response = await self.get_persistence_infos(client, owner_id, slot_ids)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['infos', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.infos, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_perpetuate_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.perpetuate_object()")
+		#--- request ---
+		persistence_slot_id = input.u16()
+		data_id = input.u64()
+		delete_last_object = input.bool()
+		await self.perpetuate_object(client, persistence_slot_id, data_id, delete_last_object)
+	
+	async def handle_unperpetuate_object(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.unperpetuate_object()")
+		#--- request ---
+		persistence_slot_id = input.u16()
+		delete_last_object = input.bool()
+		await self.unperpetuate_object(client, persistence_slot_id, delete_last_object)
+	
+	async def handle_prepare_get_object_or_meta_binary(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.prepare_get_object_or_meta_binary()")
+		#--- request ---
+		param = input.extract(DataStorePrepareGetParam)
+		response = await self.prepare_get_object_or_meta_binary(client, param)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['get_info', 'additional_meta']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.add(response.get_info)
+		output.add(response.additional_meta)
+	
+	async def handle_get_password_info(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_password_info()")
+		#--- request ---
+		data_id = input.u64()
+		response = await self.get_password_info(client, data_id)
+		
+		#--- response ---
+		if not isinstance(response, DataStorePasswordInfo):
+			raise RuntimeError("Expected DataStorePasswordInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_get_password_infos(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_password_infos()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		response = await self.get_password_infos(client, data_ids)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['infos', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.infos, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_get_metas_multiple_param(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_metas_multiple_param()")
+		#--- request ---
+		params = input.list(DataStoreGetMetaParam)
+		response = await self.get_metas_multiple_param(client, params)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['infos', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.infos, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_complete_post_objects(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.complete_post_objects()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		await self.complete_post_objects(client, data_ids)
+	
+	async def handle_change_meta(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.change_meta()")
+		#--- request ---
+		param = input.extract(DataStoreChangeMetaParam)
+		await self.change_meta(client, param)
+	
+	async def handle_change_metas(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.change_metas()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		param = input.list(DataStoreChangeMetaParam)
+		transactional = input.bool()
+		response = await self.change_metas(client, data_ids, param, transactional)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.result)
+	
+	async def handle_rate_objects(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.rate_objects()")
+		#--- request ---
+		targets = input.list(DataStoreRatingTarget)
+		param = input.list(DataStoreRateObjectParam)
+		transactional = input.bool()
+		fetch_ratings = input.bool()
+		response = await self.rate_objects(client, targets, param, transactional, fetch_ratings)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['infos', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.infos, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_post_meta_binary_with_data_id(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.post_meta_binary_with_data_id()")
+		#--- request ---
+		data_id = input.u64()
+		param = input.extract(DataStorePreparePostParam)
+		await self.post_meta_binary_with_data_id(client, data_id, param)
+	
+	async def handle_post_meta_binaries_with_data_id(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.post_meta_binaries_with_data_id()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		param = input.list(DataStorePreparePostParam)
+		transactional = input.bool()
+		response = await self.post_meta_binaries_with_data_id(client, data_ids, param, transactional)
+		
+		#--- response ---
+		if not isinstance(response, list):
+			raise RuntimeError("Expected list, got %s" %response.__class__.__name__)
+		output.list(response, output.result)
+	
+	async def handle_rate_object_with_posting(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.rate_object_with_posting()")
+		#--- request ---
+		target = input.extract(DataStoreRatingTarget)
+		rate_param = input.extract(DataStoreRateObjectParam)
+		post_param = input.extract(DataStorePreparePostParam)
+		fetch_ratings = input.bool()
+		response = await self.rate_object_with_posting(client, target, rate_param, post_param, fetch_ratings)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreRatingInfo):
+			raise RuntimeError("Expected DataStoreRatingInfo, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_rate_objects_with_posting(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.rate_objects_with_posting()")
+		#--- request ---
+		targets = input.list(DataStoreRatingTarget)
+		rate_param = input.list(DataStoreRateObjectParam)
+		post_param = input.list(DataStorePreparePostParam)
+		transactional = input.bool()
+		fetch_ratings = input.bool()
+		response = await self.rate_objects_with_posting(client, targets, rate_param, post_param, transactional, fetch_ratings)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['ratings', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.ratings, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_get_object_infos(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.get_object_infos()")
+		#--- request ---
+		data_ids = input.list(input.u64)
+		response = await self.get_object_infos(client, data_ids)
+		
+		#--- response ---
+		if not isinstance(response, rmc.RMCResponse):
+			raise RuntimeError("Expected RMCResponse, got %s" %response.__class__.__name__)
+		for field in ['infos', 'results']:
+			if not hasattr(response, field):
+				raise RuntimeError("Missing field in RMCResponse: %s" %field)
+		output.list(response.infos, output.add)
+		output.list(response.results, output.result)
+	
+	async def handle_search_object_light(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.search_object_light()")
+		#--- request ---
+		param = input.extract(DataStoreSearchParam)
+		response = await self.search_object_light(client, param)
+		
+		#--- response ---
+		if not isinstance(response, DataStoreSearchResult):
+			raise RuntimeError("Expected DataStoreSearchResult, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def handle_search_mii(self, client, input, output):
+		logger.info("DataStore_MiitopiaServer3DS.search_mii()")
+		#--- request ---
+		param = input.extract(MiiTubeSearchParam)
+		response = await self.search_mii(client, param)
+		
+		#--- response ---
+		if not isinstance(response, MiiTubeSearchResult):
+			raise RuntimeError("Expected MiiTubeSearchResult, got %s" %response.__class__.__name__)
+		output.add(response)
+	
+	async def prepare_get_object_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.prepare_get_object_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def prepare_post_object_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.prepare_post_object_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def complete_post_object_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.complete_post_object_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def delete_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.delete_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def delete_objects(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.delete_objects not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def change_meta_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.change_meta_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def change_metas_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.change_metas_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_meta(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_meta not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_metas(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_metas not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def prepare_update_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.prepare_update_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def complete_update_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.complete_update_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def search_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.search_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_notification_url(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_notification_url not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_new_arrived_notifications_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_new_arrived_notifications_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def rate_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.rate_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_rating(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_rating not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_ratings(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_ratings not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def reset_rating(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.reset_rating not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def reset_ratings(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.reset_ratings not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_specific_meta_v1(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_specific_meta_v1 not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def post_meta_binary(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.post_meta_binary not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def touch_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.touch_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_rating_with_log(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_rating_with_log not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def prepare_post_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.prepare_post_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def prepare_get_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.prepare_get_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def complete_post_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.complete_post_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_new_arrived_notifications(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_new_arrived_notifications not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_specific_meta(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_specific_meta not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_persistence_info(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_persistence_info not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_persistence_infos(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_persistence_infos not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def perpetuate_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.perpetuate_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def unperpetuate_object(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.unperpetuate_object not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def prepare_get_object_or_meta_binary(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.prepare_get_object_or_meta_binary not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_password_info(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_password_info not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_password_infos(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_password_infos not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_metas_multiple_param(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_metas_multiple_param not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def complete_post_objects(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.complete_post_objects not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def change_meta(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.change_meta not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def change_metas(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.change_metas not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def rate_objects(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.rate_objects not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def post_meta_binary_with_data_id(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.post_meta_binary_with_data_id not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def post_meta_binaries_with_data_id(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.post_meta_binaries_with_data_id not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def rate_object_with_posting(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.rate_object_with_posting not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def rate_objects_with_posting(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.rate_objects_with_posting not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def get_object_infos(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.get_object_infos not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def search_object_light(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.search_object_light not implemented")
+		raise common.RMCError("Core::NotImplemented")
+	
+	async def search_mii(self, *args):
+		logger.warning("DataStore_MiitopiaServer3DS.search_mii not implemented")
+		raise common.RMCError("Core::NotImplemented")
+

--- a/nintendo/nex/datastore_miitopia_3ds.py
+++ b/nintendo/nex/datastore_miitopia_3ds.py
@@ -1440,7 +1440,7 @@ class MiiTubeSearchResult(common.Structure):
 		stream.bool(self.has_next)
 
 
-class DataStore_MiitopiaProtocol3DS:
+class DataStoreProtocolMiitopia3DS:
 	METHOD_PREPARE_GET_OBJECT_V1 = 1
 	METHOD_PREPARE_POST_OBJECT_V1 = 2
 	METHOD_COMPLETE_POST_OBJECT_V1 = 3
@@ -1492,13 +1492,13 @@ class DataStore_MiitopiaProtocol3DS:
 	PROTOCOL_ID = 0x73
 
 
-class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
+class DataStoreClientMiitopia3DS(DataStoreProtocolMiitopia3DS):
 	def __init__(self, client):
 		self.settings = client.settings
 		self.client = client
 	
 	async def prepare_get_object_v1(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_v1()")
+		logger.info("DataStoreClientMiitopia3DS.prepare_get_object_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1509,11 +1509,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreReqGetInfoV1)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.prepare_get_object_v1 -> done")
 		return info
 	
 	async def prepare_post_object_v1(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object_v1()")
+		logger.info("DataStoreClientMiitopia3DS.prepare_post_object_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1524,11 +1524,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreReqPostInfoV1)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.prepare_post_object_v1 -> done")
 		return info
 	
 	async def complete_post_object_v1(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.complete_post_object_v1()")
+		logger.info("DataStoreClientMiitopia3DS.complete_post_object_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1538,10 +1538,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.complete_post_object_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.complete_post_object_v1 -> done")
 	
 	async def delete_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.delete_object()")
+		logger.info("DataStoreClientMiitopia3DS.delete_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1551,10 +1551,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.delete_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.delete_object -> done")
 	
 	async def delete_objects(self, param, transactional):
-		logger.info("DataStore_MiitopiaClient3DS.delete_objects()")
+		logger.info("DataStoreClientMiitopia3DS.delete_objects()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(param, stream.add)
@@ -1566,11 +1566,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.delete_objects -> done")
+		logger.info("DataStoreClientMiitopia3DS.delete_objects -> done")
 		return results
 	
 	async def change_meta_v1(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.change_meta_v1()")
+		logger.info("DataStoreClientMiitopia3DS.change_meta_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1580,10 +1580,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.change_meta_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.change_meta_v1 -> done")
 	
 	async def change_metas_v1(self, data_ids, param, transactional):
-		logger.info("DataStore_MiitopiaClient3DS.change_metas_v1()")
+		logger.info("DataStoreClientMiitopia3DS.change_metas_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -1596,11 +1596,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.change_metas_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.change_metas_v1 -> done")
 		return results
 	
 	async def get_meta(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_meta()")
+		logger.info("DataStoreClientMiitopia3DS.get_meta()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1611,11 +1611,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreMetaInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_meta -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_meta -> done")
 		return info
 	
 	async def get_metas(self, data_ids, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_metas()")
+		logger.info("DataStoreClientMiitopia3DS.get_metas()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -1629,11 +1629,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_metas -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_metas -> done")
 		return obj
 	
 	async def prepare_update_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.prepare_update_object()")
+		logger.info("DataStoreClientMiitopia3DS.prepare_update_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1644,11 +1644,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreReqUpdateInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.prepare_update_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.prepare_update_object -> done")
 		return info
 	
 	async def complete_update_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.complete_update_object()")
+		logger.info("DataStoreClientMiitopia3DS.complete_update_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1658,10 +1658,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.complete_update_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.complete_update_object -> done")
 	
 	async def search_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.search_object()")
+		logger.info("DataStoreClientMiitopia3DS.search_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1672,11 +1672,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		result = stream.extract(DataStoreSearchResult)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.search_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.search_object -> done")
 		return result
 	
 	async def get_notification_url(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_notification_url()")
+		logger.info("DataStoreClientMiitopia3DS.get_notification_url()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1687,11 +1687,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreReqGetNotificationUrlInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_notification_url -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_notification_url -> done")
 		return info
 	
 	async def get_new_arrived_notifications_v1(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications_v1()")
+		logger.info("DataStoreClientMiitopia3DS.get_new_arrived_notifications_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1704,11 +1704,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.has_next = stream.bool()
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_new_arrived_notifications_v1 -> done")
 		return obj
 	
 	async def rate_object(self, target, param, fetch_ratings):
-		logger.info("DataStore_MiitopiaClient3DS.rate_object()")
+		logger.info("DataStoreClientMiitopia3DS.rate_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(target)
@@ -1721,11 +1721,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreRatingInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.rate_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.rate_object -> done")
 		return info
 	
 	async def get_rating(self, target, access_password):
-		logger.info("DataStore_MiitopiaClient3DS.get_rating()")
+		logger.info("DataStoreClientMiitopia3DS.get_rating()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(target)
@@ -1737,11 +1737,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		rating = stream.extract(DataStoreRatingInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_rating -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_rating -> done")
 		return rating
 	
 	async def get_ratings(self, data_ids, access_password):
-		logger.info("DataStore_MiitopiaClient3DS.get_ratings()")
+		logger.info("DataStoreClientMiitopia3DS.get_ratings()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -1755,11 +1755,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_ratings -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_ratings -> done")
 		return obj
 	
 	async def reset_rating(self, target, update_password):
-		logger.info("DataStore_MiitopiaClient3DS.reset_rating()")
+		logger.info("DataStoreClientMiitopia3DS.reset_rating()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(target)
@@ -1770,10 +1770,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.reset_rating -> done")
+		logger.info("DataStoreClientMiitopia3DS.reset_rating -> done")
 	
 	async def reset_ratings(self, data_ids, transactional):
-		logger.info("DataStore_MiitopiaClient3DS.reset_ratings()")
+		logger.info("DataStoreClientMiitopia3DS.reset_ratings()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -1785,11 +1785,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.reset_ratings -> done")
+		logger.info("DataStoreClientMiitopia3DS.reset_ratings -> done")
 		return results
 	
 	async def get_specific_meta_v1(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta_v1()")
+		logger.info("DataStoreClientMiitopia3DS.get_specific_meta_v1()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1800,11 +1800,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		infos = stream.list(DataStoreSpecificMetaInfoV1)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta_v1 -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_specific_meta_v1 -> done")
 		return infos
 	
 	async def post_meta_binary(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary()")
+		logger.info("DataStoreClientMiitopia3DS.post_meta_binary()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1815,11 +1815,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		data_id = stream.u64()
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary -> done")
+		logger.info("DataStoreClientMiitopia3DS.post_meta_binary -> done")
 		return data_id
 	
 	async def touch_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.touch_object()")
+		logger.info("DataStoreClientMiitopia3DS.touch_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1829,10 +1829,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.touch_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.touch_object -> done")
 	
 	async def get_rating_with_log(self, target, access_password):
-		logger.info("DataStore_MiitopiaClient3DS.get_rating_with_log()")
+		logger.info("DataStoreClientMiitopia3DS.get_rating_with_log()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(target)
@@ -1846,11 +1846,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.log = stream.extract(DataStoreRatingLog)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_rating_with_log -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_rating_with_log -> done")
 		return obj
 	
 	async def prepare_post_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object()")
+		logger.info("DataStoreClientMiitopia3DS.prepare_post_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1861,11 +1861,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreReqPostInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.prepare_post_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.prepare_post_object -> done")
 		return info
 	
 	async def prepare_get_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object()")
+		logger.info("DataStoreClientMiitopia3DS.prepare_get_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1876,11 +1876,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreReqGetInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.prepare_get_object -> done")
 		return info
 	
 	async def complete_post_object(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.complete_post_object()")
+		logger.info("DataStoreClientMiitopia3DS.complete_post_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1890,10 +1890,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.complete_post_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.complete_post_object -> done")
 	
 	async def get_new_arrived_notifications(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications()")
+		logger.info("DataStoreClientMiitopia3DS.get_new_arrived_notifications()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1906,11 +1906,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.has_next = stream.bool()
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_new_arrived_notifications -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_new_arrived_notifications -> done")
 		return obj
 	
 	async def get_specific_meta(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta()")
+		logger.info("DataStoreClientMiitopia3DS.get_specific_meta()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -1921,11 +1921,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		infos = stream.list(DataStoreSpecificMetaInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_specific_meta -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_specific_meta -> done")
 		return infos
 	
 	async def get_persistence_info(self, owner_id, slot_id):
-		logger.info("DataStore_MiitopiaClient3DS.get_persistence_info()")
+		logger.info("DataStoreClientMiitopia3DS.get_persistence_info()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.pid(owner_id)
@@ -1937,11 +1937,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStorePersistenceInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_persistence_info -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_persistence_info -> done")
 		return info
 	
 	async def get_persistence_infos(self, owner_id, slot_ids):
-		logger.info("DataStore_MiitopiaClient3DS.get_persistence_infos()")
+		logger.info("DataStoreClientMiitopia3DS.get_persistence_infos()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.pid(owner_id)
@@ -1955,11 +1955,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_persistence_infos -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_persistence_infos -> done")
 		return obj
 	
 	async def perpetuate_object(self, persistence_slot_id, data_id, delete_last_object):
-		logger.info("DataStore_MiitopiaClient3DS.perpetuate_object()")
+		logger.info("DataStoreClientMiitopia3DS.perpetuate_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.u16(persistence_slot_id)
@@ -1971,10 +1971,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.perpetuate_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.perpetuate_object -> done")
 	
 	async def unperpetuate_object(self, persistence_slot_id, delete_last_object):
-		logger.info("DataStore_MiitopiaClient3DS.unperpetuate_object()")
+		logger.info("DataStoreClientMiitopia3DS.unperpetuate_object()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.u16(persistence_slot_id)
@@ -1985,10 +1985,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.unperpetuate_object -> done")
+		logger.info("DataStoreClientMiitopia3DS.unperpetuate_object -> done")
 	
 	async def prepare_get_object_or_meta_binary(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_or_meta_binary()")
+		logger.info("DataStoreClientMiitopia3DS.prepare_get_object_or_meta_binary()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -2001,11 +2001,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.additional_meta = stream.extract(DataStoreReqGetAdditionalMeta)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.prepare_get_object_or_meta_binary -> done")
+		logger.info("DataStoreClientMiitopia3DS.prepare_get_object_or_meta_binary -> done")
 		return obj
 	
 	async def get_password_info(self, data_id):
-		logger.info("DataStore_MiitopiaClient3DS.get_password_info()")
+		logger.info("DataStoreClientMiitopia3DS.get_password_info()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.u64(data_id)
@@ -2016,11 +2016,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStorePasswordInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_password_info -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_password_info -> done")
 		return info
 	
 	async def get_password_infos(self, data_ids):
-		logger.info("DataStore_MiitopiaClient3DS.get_password_infos()")
+		logger.info("DataStoreClientMiitopia3DS.get_password_infos()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -2033,11 +2033,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_password_infos -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_password_infos -> done")
 		return obj
 	
 	async def get_metas_multiple_param(self, params):
-		logger.info("DataStore_MiitopiaClient3DS.get_metas_multiple_param()")
+		logger.info("DataStoreClientMiitopia3DS.get_metas_multiple_param()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(params, stream.add)
@@ -2050,11 +2050,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_metas_multiple_param -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_metas_multiple_param -> done")
 		return obj
 	
 	async def complete_post_objects(self, data_ids):
-		logger.info("DataStore_MiitopiaClient3DS.complete_post_objects()")
+		logger.info("DataStoreClientMiitopia3DS.complete_post_objects()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -2064,10 +2064,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.complete_post_objects -> done")
+		logger.info("DataStoreClientMiitopia3DS.complete_post_objects -> done")
 	
 	async def change_meta(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.change_meta()")
+		logger.info("DataStoreClientMiitopia3DS.change_meta()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -2077,10 +2077,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.change_meta -> done")
+		logger.info("DataStoreClientMiitopia3DS.change_meta -> done")
 	
 	async def change_metas(self, data_ids, param, transactional):
-		logger.info("DataStore_MiitopiaClient3DS.change_metas()")
+		logger.info("DataStoreClientMiitopia3DS.change_metas()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -2093,11 +2093,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.change_metas -> done")
+		logger.info("DataStoreClientMiitopia3DS.change_metas -> done")
 		return results
 	
 	async def rate_objects(self, targets, param, transactional, fetch_ratings):
-		logger.info("DataStore_MiitopiaClient3DS.rate_objects()")
+		logger.info("DataStoreClientMiitopia3DS.rate_objects()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(targets, stream.add)
@@ -2113,11 +2113,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.rate_objects -> done")
+		logger.info("DataStoreClientMiitopia3DS.rate_objects -> done")
 		return obj
 	
 	async def post_meta_binary_with_data_id(self, data_id, param):
-		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary_with_data_id()")
+		logger.info("DataStoreClientMiitopia3DS.post_meta_binary_with_data_id()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.u64(data_id)
@@ -2128,10 +2128,10 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		stream = streams.StreamIn(data, self.settings)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.post_meta_binary_with_data_id -> done")
+		logger.info("DataStoreClientMiitopia3DS.post_meta_binary_with_data_id -> done")
 	
 	async def post_meta_binaries_with_data_id(self, data_ids, param, transactional):
-		logger.info("DataStore_MiitopiaClient3DS.post_meta_binaries_with_data_id()")
+		logger.info("DataStoreClientMiitopia3DS.post_meta_binaries_with_data_id()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -2144,11 +2144,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.post_meta_binaries_with_data_id -> done")
+		logger.info("DataStoreClientMiitopia3DS.post_meta_binaries_with_data_id -> done")
 		return results
 	
 	async def rate_object_with_posting(self, target, rate_param, post_param, fetch_ratings):
-		logger.info("DataStore_MiitopiaClient3DS.rate_object_with_posting()")
+		logger.info("DataStoreClientMiitopia3DS.rate_object_with_posting()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(target)
@@ -2162,11 +2162,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		info = stream.extract(DataStoreRatingInfo)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.rate_object_with_posting -> done")
+		logger.info("DataStoreClientMiitopia3DS.rate_object_with_posting -> done")
 		return info
 	
 	async def rate_objects_with_posting(self, targets, rate_param, post_param, transactional, fetch_ratings):
-		logger.info("DataStore_MiitopiaClient3DS.rate_objects_with_posting()")
+		logger.info("DataStoreClientMiitopia3DS.rate_objects_with_posting()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(targets, stream.add)
@@ -2183,11 +2183,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.rate_objects_with_posting -> done")
+		logger.info("DataStoreClientMiitopia3DS.rate_objects_with_posting -> done")
 		return obj
 	
 	async def get_object_infos(self, data_ids):
-		logger.info("DataStore_MiitopiaClient3DS.get_object_infos()")
+		logger.info("DataStoreClientMiitopia3DS.get_object_infos()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.list(data_ids, stream.u64)
@@ -2200,11 +2200,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		obj.results = stream.list(stream.result)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.get_object_infos -> done")
+		logger.info("DataStoreClientMiitopia3DS.get_object_infos -> done")
 		return obj
 	
 	async def search_object_light(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.search_object_light()")
+		logger.info("DataStoreClientMiitopia3DS.search_object_light()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -2215,11 +2215,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		result = stream.extract(DataStoreSearchResult)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.search_object_light -> done")
+		logger.info("DataStoreClientMiitopia3DS.search_object_light -> done")
 		return result
 	
 	async def search_mii(self, param):
-		logger.info("DataStore_MiitopiaClient3DS.search_mii()")
+		logger.info("DataStoreClientMiitopia3DS.search_mii()")
 		#--- request ---
 		stream = streams.StreamOut(self.settings)
 		stream.add(param)
@@ -2230,11 +2230,11 @@ class DataStore_MiitopiaClient3DS(DataStore_MiitopiaProtocol3DS):
 		search_result = stream.extract(MiiTubeSearchResult)
 		if not stream.eof():
 			raise ValueError("Response is bigger than expected (got %i bytes, but only %i were read)" %(stream.size(), stream.tell()))
-		logger.info("DataStore_MiitopiaClient3DS.search_mii -> done")
+		logger.info("DataStoreClientMiitopia3DS.search_mii -> done")
 		return search_result
 
 
-class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
+class DataStoreServerMiitopia3DS(DataStoreProtocolMiitopia3DS):
 	def __init__(self):
 		self.methods = {
 			self.METHOD_PREPARE_GET_OBJECT_V1: self.handle_prepare_get_object_v1,
@@ -2293,11 +2293,11 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		if method_id in self.methods:
 			await self.methods[method_id](client, input, output)
 		else:
-			logger.warning("Unknown method called on DataStore_MiitopiaServer3DS: %i", method_id)
+			logger.warning("Unknown method called on DataStoreServerMiitopia3DS: %i", method_id)
 			raise common.RMCError("Core::NotImplemented")
 	
 	async def handle_prepare_get_object_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.prepare_get_object_v1()")
+		logger.info("DataStoreServerMiitopia3DS.prepare_get_object_v1()")
 		#--- request ---
 		param = input.extract(DataStorePrepareGetParamV1)
 		response = await self.prepare_get_object_v1(client, param)
@@ -2308,7 +2308,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_prepare_post_object_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.prepare_post_object_v1()")
+		logger.info("DataStoreServerMiitopia3DS.prepare_post_object_v1()")
 		#--- request ---
 		param = input.extract(DataStorePreparePostParamV1)
 		response = await self.prepare_post_object_v1(client, param)
@@ -2319,19 +2319,19 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_complete_post_object_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.complete_post_object_v1()")
+		logger.info("DataStoreServerMiitopia3DS.complete_post_object_v1()")
 		#--- request ---
 		param = input.extract(DataStoreCompletePostParamV1)
 		await self.complete_post_object_v1(client, param)
 	
 	async def handle_delete_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.delete_object()")
+		logger.info("DataStoreServerMiitopia3DS.delete_object()")
 		#--- request ---
 		param = input.extract(DataStoreDeleteParam)
 		await self.delete_object(client, param)
 	
 	async def handle_delete_objects(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.delete_objects()")
+		logger.info("DataStoreServerMiitopia3DS.delete_objects()")
 		#--- request ---
 		param = input.list(DataStoreDeleteParam)
 		transactional = input.bool()
@@ -2343,13 +2343,13 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.result)
 	
 	async def handle_change_meta_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.change_meta_v1()")
+		logger.info("DataStoreServerMiitopia3DS.change_meta_v1()")
 		#--- request ---
 		param = input.extract(DataStoreChangeMetaParamV1)
 		await self.change_meta_v1(client, param)
 	
 	async def handle_change_metas_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.change_metas_v1()")
+		logger.info("DataStoreServerMiitopia3DS.change_metas_v1()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		param = input.list(DataStoreChangeMetaParamV1)
@@ -2362,7 +2362,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.result)
 	
 	async def handle_get_meta(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_meta()")
+		logger.info("DataStoreServerMiitopia3DS.get_meta()")
 		#--- request ---
 		param = input.extract(DataStoreGetMetaParam)
 		response = await self.get_meta(client, param)
@@ -2373,7 +2373,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_metas(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_metas()")
+		logger.info("DataStoreServerMiitopia3DS.get_metas()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		param = input.extract(DataStoreGetMetaParam)
@@ -2389,7 +2389,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_prepare_update_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.prepare_update_object()")
+		logger.info("DataStoreServerMiitopia3DS.prepare_update_object()")
 		#--- request ---
 		param = input.extract(DataStorePrepareUpdateParam)
 		response = await self.prepare_update_object(client, param)
@@ -2400,13 +2400,13 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_complete_update_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.complete_update_object()")
+		logger.info("DataStoreServerMiitopia3DS.complete_update_object()")
 		#--- request ---
 		param = input.extract(DataStoreCompleteUpdateParam)
 		await self.complete_update_object(client, param)
 	
 	async def handle_search_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.search_object()")
+		logger.info("DataStoreServerMiitopia3DS.search_object()")
 		#--- request ---
 		param = input.extract(DataStoreSearchParam)
 		response = await self.search_object(client, param)
@@ -2417,7 +2417,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_notification_url(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_notification_url()")
+		logger.info("DataStoreServerMiitopia3DS.get_notification_url()")
 		#--- request ---
 		param = input.extract(DataStoreGetNotificationUrlParam)
 		response = await self.get_notification_url(client, param)
@@ -2428,7 +2428,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_new_arrived_notifications_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_new_arrived_notifications_v1()")
+		logger.info("DataStoreServerMiitopia3DS.get_new_arrived_notifications_v1()")
 		#--- request ---
 		param = input.extract(DataStoreGetNewArrivedNotificationsParam)
 		response = await self.get_new_arrived_notifications_v1(client, param)
@@ -2443,7 +2443,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.bool(response.has_next)
 	
 	async def handle_rate_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.rate_object()")
+		logger.info("DataStoreServerMiitopia3DS.rate_object()")
 		#--- request ---
 		target = input.extract(DataStoreRatingTarget)
 		param = input.extract(DataStoreRateObjectParam)
@@ -2456,7 +2456,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_rating(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_rating()")
+		logger.info("DataStoreServerMiitopia3DS.get_rating()")
 		#--- request ---
 		target = input.extract(DataStoreRatingTarget)
 		access_password = input.u64()
@@ -2468,7 +2468,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_ratings(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_ratings()")
+		logger.info("DataStoreServerMiitopia3DS.get_ratings()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		access_password = input.u64()
@@ -2484,14 +2484,14 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_reset_rating(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.reset_rating()")
+		logger.info("DataStoreServerMiitopia3DS.reset_rating()")
 		#--- request ---
 		target = input.extract(DataStoreRatingTarget)
 		update_password = input.u64()
 		await self.reset_rating(client, target, update_password)
 	
 	async def handle_reset_ratings(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.reset_ratings()")
+		logger.info("DataStoreServerMiitopia3DS.reset_ratings()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		transactional = input.bool()
@@ -2503,7 +2503,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.result)
 	
 	async def handle_get_specific_meta_v1(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_specific_meta_v1()")
+		logger.info("DataStoreServerMiitopia3DS.get_specific_meta_v1()")
 		#--- request ---
 		param = input.extract(DataStoreGetSpecificMetaParamV1)
 		response = await self.get_specific_meta_v1(client, param)
@@ -2514,7 +2514,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.add)
 	
 	async def handle_post_meta_binary(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.post_meta_binary()")
+		logger.info("DataStoreServerMiitopia3DS.post_meta_binary()")
 		#--- request ---
 		param = input.extract(DataStorePreparePostParam)
 		response = await self.post_meta_binary(client, param)
@@ -2525,13 +2525,13 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.u64(response)
 	
 	async def handle_touch_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.touch_object()")
+		logger.info("DataStoreServerMiitopia3DS.touch_object()")
 		#--- request ---
 		param = input.extract(DataStoreTouchObjectParam)
 		await self.touch_object(client, param)
 	
 	async def handle_get_rating_with_log(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_rating_with_log()")
+		logger.info("DataStoreServerMiitopia3DS.get_rating_with_log()")
 		#--- request ---
 		target = input.extract(DataStoreRatingTarget)
 		access_password = input.u64()
@@ -2547,7 +2547,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response.log)
 	
 	async def handle_prepare_post_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.prepare_post_object()")
+		logger.info("DataStoreServerMiitopia3DS.prepare_post_object()")
 		#--- request ---
 		param = input.extract(DataStorePreparePostParam)
 		response = await self.prepare_post_object(client, param)
@@ -2558,7 +2558,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_prepare_get_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.prepare_get_object()")
+		logger.info("DataStoreServerMiitopia3DS.prepare_get_object()")
 		#--- request ---
 		param = input.extract(DataStorePrepareGetParam)
 		response = await self.prepare_get_object(client, param)
@@ -2569,13 +2569,13 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_complete_post_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.complete_post_object()")
+		logger.info("DataStoreServerMiitopia3DS.complete_post_object()")
 		#--- request ---
 		param = input.extract(DataStoreCompletePostParam)
 		await self.complete_post_object(client, param)
 	
 	async def handle_get_new_arrived_notifications(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_new_arrived_notifications()")
+		logger.info("DataStoreServerMiitopia3DS.get_new_arrived_notifications()")
 		#--- request ---
 		param = input.extract(DataStoreGetNewArrivedNotificationsParam)
 		response = await self.get_new_arrived_notifications(client, param)
@@ -2590,7 +2590,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.bool(response.has_next)
 	
 	async def handle_get_specific_meta(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_specific_meta()")
+		logger.info("DataStoreServerMiitopia3DS.get_specific_meta()")
 		#--- request ---
 		param = input.extract(DataStoreGetSpecificMetaParam)
 		response = await self.get_specific_meta(client, param)
@@ -2601,7 +2601,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.add)
 	
 	async def handle_get_persistence_info(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_persistence_info()")
+		logger.info("DataStoreServerMiitopia3DS.get_persistence_info()")
 		#--- request ---
 		owner_id = input.pid()
 		slot_id = input.u16()
@@ -2613,7 +2613,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_persistence_infos(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_persistence_infos()")
+		logger.info("DataStoreServerMiitopia3DS.get_persistence_infos()")
 		#--- request ---
 		owner_id = input.pid()
 		slot_ids = input.list(input.u16)
@@ -2629,7 +2629,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_perpetuate_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.perpetuate_object()")
+		logger.info("DataStoreServerMiitopia3DS.perpetuate_object()")
 		#--- request ---
 		persistence_slot_id = input.u16()
 		data_id = input.u64()
@@ -2637,14 +2637,14 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		await self.perpetuate_object(client, persistence_slot_id, data_id, delete_last_object)
 	
 	async def handle_unperpetuate_object(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.unperpetuate_object()")
+		logger.info("DataStoreServerMiitopia3DS.unperpetuate_object()")
 		#--- request ---
 		persistence_slot_id = input.u16()
 		delete_last_object = input.bool()
 		await self.unperpetuate_object(client, persistence_slot_id, delete_last_object)
 	
 	async def handle_prepare_get_object_or_meta_binary(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.prepare_get_object_or_meta_binary()")
+		logger.info("DataStoreServerMiitopia3DS.prepare_get_object_or_meta_binary()")
 		#--- request ---
 		param = input.extract(DataStorePrepareGetParam)
 		response = await self.prepare_get_object_or_meta_binary(client, param)
@@ -2659,7 +2659,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response.additional_meta)
 	
 	async def handle_get_password_info(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_password_info()")
+		logger.info("DataStoreServerMiitopia3DS.get_password_info()")
 		#--- request ---
 		data_id = input.u64()
 		response = await self.get_password_info(client, data_id)
@@ -2670,7 +2670,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_get_password_infos(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_password_infos()")
+		logger.info("DataStoreServerMiitopia3DS.get_password_infos()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		response = await self.get_password_infos(client, data_ids)
@@ -2685,7 +2685,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_get_metas_multiple_param(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_metas_multiple_param()")
+		logger.info("DataStoreServerMiitopia3DS.get_metas_multiple_param()")
 		#--- request ---
 		params = input.list(DataStoreGetMetaParam)
 		response = await self.get_metas_multiple_param(client, params)
@@ -2700,19 +2700,19 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_complete_post_objects(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.complete_post_objects()")
+		logger.info("DataStoreServerMiitopia3DS.complete_post_objects()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		await self.complete_post_objects(client, data_ids)
 	
 	async def handle_change_meta(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.change_meta()")
+		logger.info("DataStoreServerMiitopia3DS.change_meta()")
 		#--- request ---
 		param = input.extract(DataStoreChangeMetaParam)
 		await self.change_meta(client, param)
 	
 	async def handle_change_metas(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.change_metas()")
+		logger.info("DataStoreServerMiitopia3DS.change_metas()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		param = input.list(DataStoreChangeMetaParam)
@@ -2725,7 +2725,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.result)
 	
 	async def handle_rate_objects(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.rate_objects()")
+		logger.info("DataStoreServerMiitopia3DS.rate_objects()")
 		#--- request ---
 		targets = input.list(DataStoreRatingTarget)
 		param = input.list(DataStoreRateObjectParam)
@@ -2743,14 +2743,14 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_post_meta_binary_with_data_id(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.post_meta_binary_with_data_id()")
+		logger.info("DataStoreServerMiitopia3DS.post_meta_binary_with_data_id()")
 		#--- request ---
 		data_id = input.u64()
 		param = input.extract(DataStorePreparePostParam)
 		await self.post_meta_binary_with_data_id(client, data_id, param)
 	
 	async def handle_post_meta_binaries_with_data_id(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.post_meta_binaries_with_data_id()")
+		logger.info("DataStoreServerMiitopia3DS.post_meta_binaries_with_data_id()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		param = input.list(DataStorePreparePostParam)
@@ -2763,7 +2763,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response, output.result)
 	
 	async def handle_rate_object_with_posting(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.rate_object_with_posting()")
+		logger.info("DataStoreServerMiitopia3DS.rate_object_with_posting()")
 		#--- request ---
 		target = input.extract(DataStoreRatingTarget)
 		rate_param = input.extract(DataStoreRateObjectParam)
@@ -2777,7 +2777,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_rate_objects_with_posting(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.rate_objects_with_posting()")
+		logger.info("DataStoreServerMiitopia3DS.rate_objects_with_posting()")
 		#--- request ---
 		targets = input.list(DataStoreRatingTarget)
 		rate_param = input.list(DataStoreRateObjectParam)
@@ -2796,7 +2796,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_get_object_infos(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.get_object_infos()")
+		logger.info("DataStoreServerMiitopia3DS.get_object_infos()")
 		#--- request ---
 		data_ids = input.list(input.u64)
 		response = await self.get_object_infos(client, data_ids)
@@ -2811,7 +2811,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.list(response.results, output.result)
 	
 	async def handle_search_object_light(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.search_object_light()")
+		logger.info("DataStoreServerMiitopia3DS.search_object_light()")
 		#--- request ---
 		param = input.extract(DataStoreSearchParam)
 		response = await self.search_object_light(client, param)
@@ -2822,7 +2822,7 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def handle_search_mii(self, client, input, output):
-		logger.info("DataStore_MiitopiaServer3DS.search_mii()")
+		logger.info("DataStoreServerMiitopia3DS.search_mii()")
 		#--- request ---
 		param = input.extract(MiiTubeSearchParam)
 		response = await self.search_mii(client, param)
@@ -2833,190 +2833,190 @@ class DataStore_MiitopiaServer3DS(DataStore_MiitopiaProtocol3DS):
 		output.add(response)
 	
 	async def prepare_get_object_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.prepare_get_object_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.prepare_get_object_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def prepare_post_object_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.prepare_post_object_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.prepare_post_object_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def complete_post_object_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.complete_post_object_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.complete_post_object_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def delete_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.delete_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.delete_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def delete_objects(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.delete_objects not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.delete_objects not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def change_meta_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.change_meta_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.change_meta_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def change_metas_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.change_metas_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.change_metas_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_meta(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_meta not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_meta not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_metas(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_metas not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_metas not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def prepare_update_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.prepare_update_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.prepare_update_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def complete_update_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.complete_update_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.complete_update_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def search_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.search_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.search_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_notification_url(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_notification_url not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_notification_url not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_new_arrived_notifications_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_new_arrived_notifications_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_new_arrived_notifications_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def rate_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.rate_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.rate_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_rating(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_rating not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_rating not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_ratings(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_ratings not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_ratings not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def reset_rating(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.reset_rating not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.reset_rating not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def reset_ratings(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.reset_ratings not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.reset_ratings not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_specific_meta_v1(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_specific_meta_v1 not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_specific_meta_v1 not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def post_meta_binary(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.post_meta_binary not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.post_meta_binary not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def touch_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.touch_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.touch_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_rating_with_log(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_rating_with_log not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_rating_with_log not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def prepare_post_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.prepare_post_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.prepare_post_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def prepare_get_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.prepare_get_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.prepare_get_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def complete_post_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.complete_post_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.complete_post_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_new_arrived_notifications(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_new_arrived_notifications not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_new_arrived_notifications not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_specific_meta(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_specific_meta not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_specific_meta not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_persistence_info(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_persistence_info not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_persistence_info not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_persistence_infos(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_persistence_infos not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_persistence_infos not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def perpetuate_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.perpetuate_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.perpetuate_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def unperpetuate_object(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.unperpetuate_object not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.unperpetuate_object not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def prepare_get_object_or_meta_binary(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.prepare_get_object_or_meta_binary not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.prepare_get_object_or_meta_binary not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_password_info(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_password_info not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_password_info not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_password_infos(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_password_infos not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_password_infos not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_metas_multiple_param(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_metas_multiple_param not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_metas_multiple_param not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def complete_post_objects(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.complete_post_objects not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.complete_post_objects not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def change_meta(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.change_meta not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.change_meta not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def change_metas(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.change_metas not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.change_metas not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def rate_objects(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.rate_objects not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.rate_objects not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def post_meta_binary_with_data_id(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.post_meta_binary_with_data_id not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.post_meta_binary_with_data_id not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def post_meta_binaries_with_data_id(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.post_meta_binaries_with_data_id not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.post_meta_binaries_with_data_id not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def rate_object_with_posting(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.rate_object_with_posting not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.rate_object_with_posting not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def rate_objects_with_posting(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.rate_objects_with_posting not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.rate_objects_with_posting not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def get_object_infos(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.get_object_infos not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.get_object_infos not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def search_object_light(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.search_object_light not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.search_object_light not implemented")
 		raise common.RMCError("Core::NotImplemented")
 	
 	async def search_mii(self, *args):
-		logger.warning("DataStore_MiitopiaServer3DS.search_mii not implemented")
+		logger.warning("DataStoreServerMiitopia3DS.search_mii not implemented")
 		raise common.RMCError("Core::NotImplemented")
 


### PR DESCRIPTION
Miitopia (3DS) has an additional method present in DataStore, used to search though the Miis on Mii Central.

The protocol is labeled as 3DS as I'm not sure if the Switch version also has additional methods, and for more clarity.

Here is a markdown that could be used for the wiki: 
[DataStoreProtocol.md](https://github.com/kinnay/NintendoClients/files/13746756/DataStoreProtocol.md)

Also see: https://github.com/PretendoNetwork/nintendo-wiki/pull/15