### PR TITLE
Fix "Incorrect padding" error during Base64 decoding in dauth.py

### DIFF
--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -298,8 +298,12 @@ class DAuthClient:
 	
 	async def device_token(self, client_id):
 		challenge = await self.challenge()
+
+		data = challenge["data"]
+		if len(data) % 4 != 0:
+		    data += "=" * (4 - len(data) % 4)
 		
-		data = base64.b64decode(challenge["data"], "-_")
+		data = base64.b64decode(data, "-_")
 		
 		req = http.HTTPRequest.post("/v%i/device_auth_token" %self.api_version)
 		req.rawform = {


### PR DESCRIPTION
This pull request addresses the "binascii.Error: Incorrect padding" issue that occurs in the device_token method when decoding challenge["data"]. The problem arises when the Base64-encoded string lacks proper padding. The changes ensure the string is padded correctly before decoding, following the Base64 standard.

Changes made:

Added a check for the length of the Base64 string to ensure it is a multiple of 4.
Appended the necessary = characters to complete the padding if required.
Impact:

Fixes the error: binascii.Error: Incorrect padding.
Improves the robustness of the device_token method in handling improperly padded Base64 strings.

