### PR TITLE
device_token errors can be nested within the array

### DIFF
--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -456,10 +456,11 @@ class DAuthClient:
 		token_requests = [{"client_id": "%016x" %client_id} for client_id in client_ids]
 		response = await self.request_tokens(token_requests, edge_tokens=False)
 
-		for result in response["results"]:
-			if "error" in result:
-				logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
-				raise DAuthError(result["error"])
+		if "results" in response:
+			for result in response["results"]:
+				if "error" in result:
+					logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
+					raise DAuthError(result["error"])
 
 		return response
 	
@@ -467,10 +468,11 @@ class DAuthClient:
 		token_requests = [{"client_id": "%016x" %client_id, "vendor_id": vendor_id} for client_id, vendor_id in token_requests]
 		response = await self.request_tokens(token_requests, edge_tokens=True)
 
-		for result in response["results"]:
-			if "error" in result:
-				logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
-				raise DAuthError(result["error"])
+		if "results" in response:
+			for result in response["results"]:
+				if "error" in result:
+					logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
+					raise DAuthError(result["error"])
 
 		return response
 	

--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -271,8 +271,14 @@ class DAuthError(Exception):
 	
 	def __init__(self, response):
 		self.response = response
-		self.code = int(response.json["errors"][0]["code"])
-		self.message = response.json["errors"][0]["message"]
+
+		if type(response) is dict:
+			# Returned in device_tokens and edge_tokens
+			self.code = int(response["code"])
+			self.message = response["message"]
+		else:
+			self.code = int(response.json["errors"][0]["code"])
+			self.message = response.json["errors"][0]["message"]
 	
 	def __str__(self):
 		return self.message

--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -461,28 +461,12 @@ class DAuthClient:
 		
 	async def device_tokens(self, client_ids):
 		token_requests = [{"client_id": "%016x" %client_id} for client_id in client_ids]
-		response = await self.request_tokens(token_requests, edge_tokens=False)
+		return await self.request_tokens(token_requests, edge_tokens=False)
 
-		if response and "results" in response:
-			for result in response["results"]:
-				if "error" in result:
-					logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
-					raise DAuthError(result["error"])
-
-		return response
-	
 	async def edge_tokens(self, token_requests):
 		token_requests = [{"client_id": "%016x" %client_id, "vendor_id": vendor_id} for client_id, vendor_id in token_requests]
-		response = await self.request_tokens(token_requests, edge_tokens=True)
+		return await self.request_tokens(token_requests, edge_tokens=True)
 
-		if response and "results" in response:
-			for result in response["results"]:
-				if "error" in result:
-					logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
-					raise DAuthError(result["error"])
-
-		return response
-	
 	async def preload_device_tokens(self):
 		return await self.device_tokens(PRELOADED_DEVICE_TOKENS)
 	

--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -456,7 +456,7 @@ class DAuthClient:
 		token_requests = [{"client_id": "%016x" %client_id} for client_id in client_ids]
 		response = await self.request_tokens(token_requests, edge_tokens=False)
 
-		if "results" in response:
+		if response and "results" in response:
 			for result in response["results"]:
 				if "error" in result:
 					logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
@@ -468,7 +468,7 @@ class DAuthClient:
 		token_requests = [{"client_id": "%016x" %client_id, "vendor_id": vendor_id} for client_id, vendor_id in token_requests]
 		response = await self.request_tokens(token_requests, edge_tokens=True)
 
-		if "results" in response:
+		if response and "results" in response:
 			for result in response["results"]:
 				if "error" in result:
 					logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])

--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -450,7 +450,7 @@ class DAuthClient:
 		token_requests = [{"client_id": "%016x" %client_id} for client_id in client_ids]
 		response = await self.request_tokens(token_requests, edge_tokens=False)
 
-		for result in response:
+		for result in response["results"]:
 			if "error" in result:
 				logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
 				raise DAuthError(result["error"])
@@ -461,7 +461,7 @@ class DAuthClient:
 		token_requests = [{"client_id": "%016x" %client_id, "vendor_id": vendor_id} for client_id, vendor_id in token_requests]
 		response = await self.request_tokens(token_requests, edge_tokens=True)
 
-		for result in response:
+		for result in response["results"]:
 			if "error" in result:
 				logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
 				raise DAuthError(result["error"])

--- a/nintendo/switch/dauth.py
+++ b/nintendo/switch/dauth.py
@@ -448,11 +448,25 @@ class DAuthClient:
 		
 	async def device_tokens(self, client_ids):
 		token_requests = [{"client_id": "%016x" %client_id} for client_id in client_ids]
-		return await self.request_tokens(token_requests, edge_tokens=False)
+		response = await self.request_tokens(token_requests, edge_tokens=False)
+
+		for result in response:
+			if "error" in result:
+				logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
+				raise DAuthError(result["error"])
+
+		return response
 	
 	async def edge_tokens(self, token_requests):
 		token_requests = [{"client_id": "%016x" %client_id, "vendor_id": vendor_id} for client_id, vendor_id in token_requests]
-		return await self.request_tokens(token_requests, edge_tokens=True)
+		response = await self.request_tokens(token_requests, edge_tokens=True)
+
+		for result in response:
+			if "error" in result:
+				logger.error("  (%s) %s", result["error"]["code"], result["error"]["message"])
+				raise DAuthError(result["error"])
+
+		return response
 	
 	async def preload_device_tokens(self):
 		return await self.device_tokens(PRELOADED_DEVICE_TOKENS)

--- a/tests/switch/test_dauth.py
+++ b/tests/switch/test_dauth.py
@@ -214,7 +214,9 @@ async def test_dauth_2000():
 			return response
 		else:
 			assert request.encode().decode() == DEVICE_TOKEN_REQUEST_2000
-			return http.HTTPResponse(200)
+			response = http.HTTPResponse(200)
+			response.json = {"results": []}
+			return response
 	
 	async with http.serve(handler, "localhost", 12345):
 		keys = {
@@ -244,7 +246,9 @@ async def test_edge_token_2000():
 			return response
 		else:
 			assert request.encode().decode() == EDGE_TOKEN_REQUEST_2000
-			return http.HTTPResponse(200)
+			response = http.HTTPResponse(200)
+			response.json = {"results": []}
+			return response
 	
 	async with http.serve(handler, "localhost", 12345):
 		keys = {


### PR DESCRIPTION
When calling `device_tokens` or `edge_tokens` the `error` field can be nested within one of the results. This PR correctly identifies that case and returns a `DAuthError` accordingly.